### PR TITLE
User can now map some indicators to Various Leds

### DIFF
--- a/Aircrafts/A10C/A10C_Listener.cs
+++ b/Aircrafts/A10C/A10C_Listener.cs
@@ -1,4 +1,4 @@
-using DCS_BIOS.Serialized;
+﻿using DCS_BIOS.Serialized;
 using WCtrlDcsBiosBridge.Services;
 using WwDevicesDotNet;
 
@@ -119,12 +119,6 @@ internal partial class A10C_Listener : AircraftListener
                 SetCduDisplayBrightnessPercent(Math.Min(100, currentBrightness + BRT_STEP));
         });
 
-        // --- LEDs ---
-        RegisterUInt("CANOPY_UNLOCKED",    v => SetCduLeds(fm2: v == 1));
-        RegisterUInt("NOSEWHEEL_STEERING", v => SetCduLeds(ind: v == 1));
-        RegisterUInt("GUN_READY",          v => SetCduLeds(fm1: v == 1));
-        RegisterUInt("MASTER_CAUTION",     v => SetCduLeds(fail: v == 1));
-
         // --- CDU display lines ---
         bool bottomAligned = options.A10C.DisplayBottomAligned;
         for (int i = 0; i < cduLines.Length; i++)
@@ -191,11 +185,6 @@ internal partial class A10C_Listener : AircraftListener
         }
 
         RegisterUInt("IAS_US_INT", v => FlightDeck.Speed = (int)v);
-
-        RegisterUInt("GEAR_L_SAFE", v => FlightDeck.GearLeftDown = v == 1);
-        RegisterUInt("GEAR_N_SAFE", v => FlightDeck.GearNoseDown = v == 1);
-        RegisterUInt("GEAR_R_SAFE", v => FlightDeck.GearRightDown = v == 1);
-        RegisterUInt("HANDLE_GEAR_WARNING", v => FlightDeck.GearWarning = v == 1);
 
         RegisterStr("CLOCK_ETC", s =>
         {

--- a/Aircrafts/AH64-D_Listener.cs
+++ b/Aircrafts/AH64-D_Listener.cs
@@ -1,4 +1,4 @@
-using WwDevicesDotNet;
+﻿using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Aircrafts;
 
@@ -37,8 +37,7 @@ internal class AH64D_Listener : AircraftListener
 
         // --- LEDs (PLT) ---
         // Note that they share the same Address but bit is different (10 and 11)
-        RegisterUInt("PLT_MASTER_CAUTION_L", v => SetCduLeds(fail: v == 1));
-        RegisterUInt("PLT_MASTER_WARNING_L", v => SetCduLeds(ind: v == 1));
+        // The two master lights are declared in LedDefaults.
 
         // --- PLT EUFD lines → DEFAULT_PAGE ---
         RegisterStr("PLT_EUFD_LINE14", s =>

--- a/Aircrafts/AircraftListener.cs
+++ b/Aircrafts/AircraftListener.cs
@@ -1,4 +1,4 @@
-using ClassLibraryCommon;
+﻿using ClassLibraryCommon;
 using System.Collections.Concurrent;
 using DCS_BIOS.ControlLocator;
 using DCS_BIOS.EventArgs;
@@ -8,14 +8,25 @@ using Newtonsoft.Json;
 using System.IO;
 using Timer = System.Timers.Timer;
 using WwDevicesDotNet;
+using WCtrlDcsBiosBridge.Config;
 using WCtrlDcsBiosBridge.Devices.Cdu;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
 
 namespace WCtrlDcsBiosBridge.Aircrafts;
 
 internal abstract class AircraftListener : IDcsBiosListener, IDisposable
 {
     private static readonly double _TICK_DISPLAY = 100;
+
+    // The annunciators run at 30 Hz on their own timer while the screen keeps its 10 Hz.
+    // DCS-BIOS exports every rendered frame, so the tick is the only thing quantizing a lamp,
+    // and a flashing caution sampled at 10 Hz blinks visibly slower than the cockpit's. A LED
+    // tick costs nothing unless something moved (see CduRenderer.RenderLeds), a screen tick
+    // copies the whole buffer.
+    private static readonly double _TICK_LEDS = 33;
+
     private readonly Timer _DisplayCDUTimer;
+    private readonly Timer _LedCDUTimer;
     protected AircraftCduContext? cdu;
 
     private bool _disposed;
@@ -208,6 +219,20 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
                 App.Logger.Error(ex, "CDU render tick failed");
             }
         };
+
+        _LedCDUTimer = new(_TICK_LEDS);
+        _LedCDUTimer.Elapsed += (_, _) =>
+        {
+            // Same reasoning as the display tick: an unplugged device must not crash the app.
+            try
+            {
+                cdu?.RenderLeds();
+            }
+            catch (Exception ex)
+            {
+                App.Logger.Error(ex, "CDU LED tick failed");
+            }
+        };
     }
 
     /// <summary>
@@ -281,7 +306,11 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
     {
         InitializeDcsBiosOutputs();
 
+        // This aircraft's declared LED defaults, then whatever it computes for itself, then
+        // the user's own bindings — each layer having the last word over the one before it.
+        RegisterDefaultLedBindings();
         RegisterFrontpanelControls();
+        RegisterUserLedBindings();
 
         if (cdu != null)
         {
@@ -322,6 +351,7 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
 
         cdu?.Render(pages[_currentPage]);
         _DisplayCDUTimer.Start();
+        _LedCDUTimer.Start();
 
     }
 
@@ -339,6 +369,7 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
         cdu = null;
 
         _DisplayCDUTimer.Stop();
+        _LedCDUTimer.Stop();
 
         BIOSEventHandler.DetachConnectionListener(this);
         BIOSEventHandler.DetachDataListener(this);
@@ -389,6 +420,11 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
         }
     }
 
+    /// <summary>
+    /// Sets the MCDU annunciators this aircraft drives. LEDs the user has bound to a
+    /// DCS-BIOS control of their own are left alone: a user binding wins over the
+    /// aircraft's built-in one, the same rule the frontpanel renderers follow.
+    /// </summary>
     protected void SetCduLeds(
         bool? fail = null,
         bool? fm1 = null,
@@ -397,18 +433,166 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
         bool? ind = null,
         bool? rdy = null)
     {
-        if (cdu == null) return;
-        lock (cdu.State.SyncRoot)
+        if (fail.HasValue) SetDefaultCduLed(McduLed.Fail, fail.Value);
+        if (fm1.HasValue) SetDefaultCduLed(McduLed.Fm1, fm1.Value);
+        if (fm2.HasValue) SetDefaultCduLed(McduLed.Fm2, fm2.Value);
+        if (fm.HasValue) SetDefaultCduLed(McduLed.Fm, fm.Value);
+        if (ind.HasValue) SetDefaultCduLed(McduLed.Ind, ind.Value);
+        if (rdy.HasValue) SetDefaultCduLed(McduLed.Rdy, rdy.Value);
+    }
+
+    /// <summary>Writes an annunciator the aircraft owns, unless the user took it over.</summary>
+    private void SetDefaultCduLed(McduLed led, bool on)
+    {
+        if (IsUserBound(led)) return;
+        WriteCduLed(led, on);
+    }
+
+    /// <summary>
+    /// Writes one annunciator. Only marks the LEDs dirty when a value actually changed: some
+    /// aircraft read their lamps out of a shared register that DCS-BIOS resends whenever any
+    /// bit in it moves, and a dirty flag costs a USB write on the next render tick.
+    /// </summary>
+    private void WriteCduLed(McduLed led, bool on)
+    {
+        var c = cdu;
+        if (c == null) return;
+
+        lock (c.State.SyncRoot)
         {
-            if (fail.HasValue) cdu.State.LedFail = fail.Value;
-            if (fm1.HasValue) cdu.State.LedFm1 = fm1.Value;
-            if (fm2.HasValue) cdu.State.LedFm2 = fm2.Value;
-            if (fm.HasValue) cdu.State.LedFm = fm.Value;
-            if (ind.HasValue) cdu.State.LedInd = ind.Value;
-            if (rdy.HasValue) cdu.State.LedRdy = rdy.Value;
-            cdu.State.LedsDirty = true;
+            var state = c.State;
+            bool changed;
+
+            switch (led)
+            {
+                case McduLed.Fail: changed = state.LedFail != on; state.LedFail = on; break;
+                case McduLed.Fm1: changed = state.LedFm1 != on; state.LedFm1 = on; break;
+                case McduLed.Fm2: changed = state.LedFm2 != on; state.LedFm2 = on; break;
+                case McduLed.Fm: changed = state.LedFm != on; state.LedFm = on; break;
+                case McduLed.Ind: changed = state.LedInd != on; state.LedInd = on; break;
+                case McduLed.Rdy: changed = state.LedRdy != on; state.LedRdy = on; break;
+                default: changed = false; break;
+            }
+
+            if (changed) state.LedsDirty = true;
         }
     }
+
+    // ── User LED bindings (ledmappings.json) ─────────────────────────────────
+
+    /// <summary>MCDU annunciators the user bound on this aircraft.</summary>
+    private readonly HashSet<McduLed> _userBoundCduLeds = new();
+
+    private bool IsUserBound(McduLed led) => _userBoundCduLeds.Contains(led);
+
+    /// <summary>
+    /// Registers this aircraft's declared LED defaults (see <see cref="LedDefaults"/>). Keeping
+    /// them in a table rather than in each listener means the LED editor can show what a LED
+    /// already follows without starting the aircraft, and cannot fall out of step with what the
+    /// bridge actually does.
+    /// </summary>
+    private void RegisterDefaultLedBindings()
+    {
+        var defaults = LedDefaults.For(descriptor);
+
+        foreach (var signal in defaults.Signals)
+        {
+            // Each control keeps its own last value, so a signal read off several of them
+            // reflects all of them and not just whichever moved last.
+            var lit = new bool[signal.Controls.Count];
+
+            for (var i = 0; i < signal.Controls.Count; i++)
+            {
+                var slot = i;
+                TryRegisterDefault(signal.Controls[slot], v =>
+                {
+                    lit[slot] = v != 0;
+                    FlightDeck.SetSignal(signal.Signal, Array.IndexOf(lit, true) >= 0);
+                });
+            }
+        }
+
+        foreach (var led in defaults.McduLeds)
+            TryRegisterDefault(led.Control, v => SetDefaultCduLed(led.Led, v != 0));
+    }
+
+    /// <summary>
+    /// Registers a declared default. Same reasoning as the user bindings: a control the
+    /// installed DCS-BIOS no longer defines must cost that one LED, not the bridge.
+    /// </summary>
+    private void TryRegisterDefault(string controlId, Action<uint> handler)
+    {
+        try
+        {
+            RegisterUInt(controlId, handler);
+        }
+        catch (Exception ex)
+        {
+            App.Logger.Warn(ex, $"Built-in LED default ignored: '{controlId}' is not a control of " +
+                                $"the {descriptor.DisplayName}");
+        }
+    }
+
+    /// <summary>
+    /// Registers the user's own LED bindings for this aircraft. Frontpanel LEDs land in
+    /// <see cref="FlightDeck"/> for the renderers to pick up; MCDU LEDs are written straight
+    /// to the CDU state. Called from <see cref="Start"/> for every aircraft — no listener
+    /// has to know the feature exists.
+    /// </summary>
+    private void RegisterUserLedBindings()
+    {
+        var bindings = LedMappingStore.ForAircraft(descriptor.DisplayName);
+        if (bindings.Count == 0) return;
+
+        // User LEDs are lighting like any other: SimApp Pro users own the panels.
+        if (options.DisableLightingManagement)
+        {
+            App.Logger.Info($"{bindings.Count} user LED binding(s) skipped: lighting management is disabled");
+            return;
+        }
+
+        foreach (var binding in bindings)
+        {
+            if (binding.Device == LedDeviceFamily.Mcdu)
+            {
+                if (LedCatalog.ParseMcduLed(binding.Led) is not McduLed led) continue;
+
+                // Only claim the LED once the control resolved: a binding that failed to
+                // register must not suppress the aircraft's own use of that annunciator.
+                if (TryRegisterUserLed(binding, v => WriteCduLed(led, binding.IsOn(v))))
+                    _userBoundCduLeds.Add(led);
+            }
+            else
+            {
+                TryRegisterUserLed(binding, v => FlightDeck.SetUserLed(binding.Device, binding.Led, binding.IsOn(v)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Registers a handler for a user-supplied control id. Unlike the hard-coded ids the
+    /// listeners use, this one comes from a file the user (or whoever shared it) wrote, and
+    /// <see cref="DCSBIOSControlLocator.GetUIntDCSBIOSOutput"/> throws on an identifier the
+    /// module does not define — a stale binding after a DCS-BIOS update would otherwise take
+    /// the whole bridge down. Report it and carry on with the rest.
+    /// </summary>
+    private bool TryRegisterUserLed(LedBinding binding, Action<uint> handler)
+    {
+        try
+        {
+            RegisterUInt(binding.Control, handler);
+            App.Logger.Info($"User LED binding: {binding.Device}/{binding.Led} follows {binding.Control}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            App.Logger.Warn(ex, $"User LED binding ignored: {binding.Device}/{binding.Led} cannot follow " +
+                                $"'{binding.Control}' on the {descriptor.DisplayName}");
+            return false;
+        }
+    }
+
+
 
     protected virtual void InitializeDcsBiosOutputs() { }
     protected abstract void RegisterCduControls();
@@ -459,6 +643,7 @@ internal abstract class AircraftListener : IDcsBiosListener, IDisposable
         {
             Stop();
             _DisplayCDUTimer.Dispose();
+            _LedCDUTimer.Dispose();
         }
 
         _disposed = true;

--- a/Aircrafts/CH47F_Listener.cs
+++ b/Aircrafts/CH47F_Listener.cs
@@ -1,4 +1,4 @@
-using DCS_BIOS.Serialized;
+﻿using DCS_BIOS.Serialized;
 using WwDevicesDotNet;
 using System.Linq;
 
@@ -70,7 +70,7 @@ internal class CH47F_Listener : AircraftListener
     protected override void RegisterCduControls()
     {
         // --- LED ---
-        RegisterUInt("PLT_MASTER_CAUTION_LIGHT", v => SetCduLeds(fail: v != 0));
+        // The master caution is declared in LedDefaults.
 
         // --- Brightness (display step knob) ---
         RegisterLight("PLT_CDU_BRT", v =>

--- a/Aircrafts/F14/F14_Listener.cs
+++ b/Aircrafts/F14/F14_Listener.cs
@@ -1,4 +1,4 @@
-using WwDevicesDotNet;
+﻿using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Aircrafts.F14;
 
@@ -9,7 +9,6 @@ internal partial class F14_Listener : AircraftListener
     private readonly Key _rioDisplayKey;
     private readonly Key _radioDisplayKey;
 
-    private bool _gearLOff, _gearNoseOff, _gearROff;
 
     private string _clockH  = "00";
     private string _clockM  = "00";
@@ -59,13 +58,7 @@ internal partial class F14_Listener : AircraftListener
 
     protected override void RegisterFrontpanelControls()
     {
-        RegisterUInt("PLT_GEAR_L_IND_L",    v => FlightDeck.GearLeftDown  = v == 1);
-        RegisterUInt("PLT_GEAR_NOSE_IND_L", v => FlightDeck.GearNoseDown  = v == 1);
-        RegisterUInt("PLT_GEAR_R_IND_L",    v => FlightDeck.GearRightDown = v == 1);
-
-        RegisterUInt("PLT_GEAR_L_OFF_L",    v => { _gearLOff    = v == 1; FlightDeck.GearWarning = _gearLOff || _gearNoseOff || _gearROff; });
-        RegisterUInt("PLT_GEAR_NOSE_OFF_L", v => { _gearNoseOff = v == 1; FlightDeck.GearWarning = _gearLOff || _gearNoseOff || _gearROff; });
-        RegisterUInt("PLT_GEAR_R_OFF_L",    v => { _gearROff    = v == 1; FlightDeck.GearWarning = _gearLOff || _gearNoseOff || _gearROff; });
+        // The gear lights, warning included, are declared in LedDefaults.
 
         RegisterUInt("PLT_CLOCK_H",  (ctrl, v) => { _clockH  = ((int)(v * 12 / (ctrl.MaxValue + 1))).ToString("D2"); FlightDeck.ClockUtcTime = _clockH + _clockM + "00"; });
         RegisterUInt("PLT_CLOCK_M",  (ctrl, v) => { _clockM  = ((int)(v * 60 / (ctrl.MaxValue + 1))).ToString("D2"); FlightDeck.ClockUtcTime = _clockH + _clockM + "00"; });

--- a/Aircrafts/F16C/F16C_Listener.cs
+++ b/Aircrafts/F16C/F16C_Listener.cs
@@ -1,4 +1,4 @@
-using DCS_BIOS.EventArgs;
+﻿using DCS_BIOS.EventArgs;
 using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Aircrafts;
@@ -80,8 +80,6 @@ internal partial class F16C_Listener : AircraftListener
         RegisterLight("PRI_CONSOLES_BRT_KNB",    (ctrl, v) => SetCduBacklightBrightnessPercent((int)(v * 100 / ctrl.MaxValue)));
         RegisterLight("PRI_DATA_DISPLAY_BRT_KNB", (ctrl, v) => SetCduDisplayBrightnessPercent((int)(v * 100 / ctrl.MaxValue)));
 
-        RegisterUInt("LIGHT_MASTER_CAUTION", v => SetCduLeds(fail: v == 1));
-
         RegisterDedControls();
         RegisterNavControls();
         RegisterRwrControls();
@@ -89,10 +87,7 @@ internal partial class F16C_Listener : AircraftListener
 
     protected override void RegisterFrontpanelControls()
     {
-        RegisterUInt("LIGHT_GEAR_L",    v => FlightDeck.GearLeftDown = v == 1);
-        RegisterUInt("LIGHT_GEAR_N",    v => FlightDeck.GearNoseDown = v == 1);
-        RegisterUInt("LIGHT_GEAR_R",    v => FlightDeck.GearRightDown = v == 1);
-        RegisterUInt("LIGHT_GEAR_WARN", v => FlightDeck.GearWarning = v == 1);
+        // Gear lights and the master caution are declared in LedDefaults.
     }
 
     protected override void Dispose(bool disposing)

--- a/Aircrafts/FA18C/FA18C_Listener.cs
+++ b/Aircrafts/FA18C/FA18C_Listener.cs
@@ -1,4 +1,4 @@
-using DCS_BIOS.EventArgs;
+﻿using DCS_BIOS.EventArgs;
 using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Aircrafts;
@@ -7,7 +7,6 @@ internal partial class FA18C_Listener : AircraftListener
 {
     private const string IFEI_PAGE = "IFEI";
 
-    uint _masterCaution = 0;
     uint _lightMode = 0; // 2=NVG, 1=NITE, 0=DAY
 
     private readonly Key _nextPageKey;
@@ -44,27 +43,13 @@ internal partial class FA18C_Listener : AircraftListener
         }
 
         RegisterUInt("COCKKPIT_LIGHT_MODE_SW", v => _lightMode = v);
-        RegisterUInt("MASTER_CAUTION_LT", v =>
-        {
-            if (_masterCaution != v)
-            {
-                _masterCaution = v;
-                SetCduLeds(fail: _masterCaution != 0);
-            }
-        });
-
         RegisterUfcControls();
         RegisterIfeiControls();
     }
 
     protected override void RegisterFrontpanelControls()
     {
-        RegisterUInt("FLP_LG_LEFT_GEAR_LT",    v => FlightDeck.GearLeftDown = v == 1);
-        RegisterUInt("FLP_LG_RIGHT_GEAR_LT",   v => FlightDeck.GearRightDown = v == 1);
-        RegisterUInt("FLP_LG_NOSE_GEAR_LT",    v => FlightDeck.GearNoseDown = v == 1);
-        RegisterUInt("LANDING_GEAR_HANDLE_LT", v => FlightDeck.GearWarning = v == 1);
-        RegisterUInt("FLP_LG_HALF_FLAPS_LT",   v => FlightDeck.LedAutoBrkLoDecel = v == 1);
-        RegisterUInt("FLP_LG_FULL_FLAPS_LT",   v => FlightDeck.LedAutoBrkMedDecel = v == 1);
+        // Gear and flap lights are declared in LedDefaults.
 
         RegisterIfeiFrontPanelControls();
     }

--- a/Aircrafts/FlightDeckState.cs
+++ b/Aircrafts/FlightDeckState.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+
 namespace WCtrlDcsBiosBridge.Aircrafts;
 
 /// <summary>
@@ -7,6 +10,77 @@ namespace WCtrlDcsBiosBridge.Aircrafts;
 /// </summary>
 internal class FlightDeckState
 {
+    // User LED bindings bypass the semantic properties below: the listener evaluates the
+    // user's condition when the DCS-BIOS value arrives and drops the resulting on/off here,
+    // keyed by device family and LED id. Concurrent because DCS-BIOS handlers write on the
+    // receive thread while the frontpanel hub reads on its 100 ms render timer.
+    private readonly ConcurrentDictionary<string, bool> _userLeds = new();
+
+    private static string UserLedKey(LedDeviceFamily family, string ledId) =>
+        $"{family}:{ledId.ToUpperInvariant()}";
+
+    /// <summary>Records the evaluated state of a user-bound LED.</summary>
+    public void SetUserLed(LedDeviceFamily family, string ledId, bool on) =>
+        _userLeds[UserLedKey(family, ledId)] = on;
+
+    /// <summary>
+    /// Reads a user-bound LED. False when the user did not bind it — the renderer then
+    /// leaves that LED to its built-in mapping.
+    /// </summary>
+    public bool TryGetUserLed(LedDeviceFamily family, string ledId, out bool on) =>
+        _userLeds.TryGetValue(UserLedKey(family, ledId), out on);
+
+    /// <summary>Whether any user binding writes here, so renderers can skip the overlay.</summary>
+    public bool HasUserLeds => !_userLeds.IsEmpty;
+
+    /// <summary>
+    /// Writes one of the LED signals by name, for the declared per-aircraft defaults. The
+    /// properties below stay the way listeners and renderers read them; this is only the door
+    /// that a table-driven default comes in through.
+    /// </summary>
+    public void SetSignal(FlightDeckSignal signal, bool on)
+    {
+        switch (signal)
+        {
+            case FlightDeckSignal.GearLeftDown: GearLeftDown = on; break;
+            case FlightDeckSignal.GearNoseDown: GearNoseDown = on; break;
+            case FlightDeckSignal.GearRightDown: GearRightDown = on; break;
+            case FlightDeckSignal.GearWarning: GearWarning = on; break;
+            case FlightDeckSignal.AutoBrkLoOn: LedAutoBrkLoOn = on; break;
+            case FlightDeckSignal.AutoBrkMedOn: LedAutoBrkMedOn = on; break;
+            case FlightDeckSignal.AutoBrkMaxOn: LedAutoBrkMaxOn = on; break;
+            case FlightDeckSignal.AutoBrkLoDecel: LedAutoBrkLoDecel = on; break;
+            case FlightDeckSignal.AutoBrkMedDecel: LedAutoBrkMedDecel = on; break;
+            case FlightDeckSignal.AutoBrkMaxDecel: LedAutoBrkMaxDecel = on; break;
+            case FlightDeckSignal.TerrOnNd: LedTerrOnNd = on; break;
+            case FlightDeckSignal.BrkFanOn: LedBrkFanOn = on; break;
+            case FlightDeckSignal.BrkFanHot: LedBrkFanHot = on; break;
+        }
+    }
+
+    /// <summary>
+    /// Reads a LED signal. Null means this aircraft does not publish it, which renderers show
+    /// as off.
+    /// </summary>
+    public bool? GetSignal(FlightDeckSignal signal) => signal switch
+    {
+        FlightDeckSignal.GearLeftDown => GearLeftDown,
+        FlightDeckSignal.GearNoseDown => GearNoseDown,
+        FlightDeckSignal.GearRightDown => GearRightDown,
+        FlightDeckSignal.GearWarning => GearWarning,
+        FlightDeckSignal.AutoBrkLoOn => LedAutoBrkLoOn,
+        FlightDeckSignal.AutoBrkMedOn => LedAutoBrkMedOn,
+        FlightDeckSignal.AutoBrkMaxOn => LedAutoBrkMaxOn,
+        FlightDeckSignal.AutoBrkLoDecel => LedAutoBrkLoDecel,
+        FlightDeckSignal.AutoBrkMedDecel => LedAutoBrkMedDecel,
+        FlightDeckSignal.AutoBrkMaxDecel => LedAutoBrkMaxDecel,
+        FlightDeckSignal.TerrOnNd => LedTerrOnNd,
+        FlightDeckSignal.BrkFanOn => LedBrkFanOn,
+        FlightDeckSignal.BrkFanHot => LedBrkFanHot,
+        _ => null,
+    };
+
+
     public int? Speed { get; set; }
     public int? Heading { get; set; }
     public int? Altitude { get; set; }

--- a/Aircrafts/LedDefaults.cs
+++ b/Aircrafts/LedDefaults.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+
+namespace WCtrlDcsBiosBridge.Aircrafts;
+
+/// <summary>
+/// The device-agnostic LED signals an aircraft can publish. A listener says "the left gear is
+/// down"; each panel family decides which of its LEDs shows that, so one declaration lights
+/// the right lamp on every panel that has one.
+/// </summary>
+public enum FlightDeckSignal
+{
+    GearLeftDown,
+    GearNoseDown,
+    GearRightDown,
+    GearWarning,
+    AutoBrkLoOn,
+    AutoBrkMedOn,
+    AutoBrkMaxOn,
+    AutoBrkLoDecel,
+    AutoBrkMedDecel,
+    AutoBrkMaxDecel,
+    TerrOnNd,
+    BrkFanOn,
+    BrkFanHot,
+}
+
+/// <summary>
+/// A signal this aircraft reads off DCS-BIOS controls: lit when any of them is non-zero.
+/// One control is the usual case; several cover a lamp that answers to a set of conditions,
+/// like a gear warning that lights when any leg is not locked down.
+/// </summary>
+public sealed record SignalDefault(FlightDeckSignal Signal, IReadOnlyList<string> Controls)
+{
+    public SignalDefault(FlightDeckSignal signal, params string[] controls)
+        : this(signal, (IReadOnlyList<string>)controls) { }
+}
+
+/// <summary>An MCDU annunciator this aircraft drives straight from one DCS-BIOS control.</summary>
+public sealed record McduLedDefault(McduLed Led, string Control);
+
+/// <summary>
+/// What the editor shows for a LED nobody has bound: the control it already follows, or a note
+/// naming what the code works it out from. Both null means the LED is idle on this aircraft.
+/// </summary>
+public sealed record LedDefaultInfo(IReadOnlyList<string>? Controls, string? ComputedFrom)
+{
+    public static readonly LedDefaultInfo None = new(null, null);
+
+    /// <summary>A signal read off these controls.</summary>
+    public static LedDefaultInfo From(IReadOnlyList<string> controls) => new(controls, null);
+
+    public static LedDefaultInfo From(string control) => new(new[] { control }, null);
+
+    /// <summary>A signal the listener works out, described by what it derives it from.</summary>
+    public static LedDefaultInfo Computed(string from) => new(null, from);
+
+    public bool Exists => Controls is { Count: > 0 } || ComputedFrom != null;
+
+    /// <summary>
+    /// Names the controls compactly enough for a placeholder: the first one, and how many
+    /// others join it.
+    /// </summary>
+    public string? Describe()
+    {
+        if (Controls is not { Count: > 0 }) return null;
+        return Controls.Count == 1 ? Controls[0] : $"{Controls[0]} +{Controls.Count - 1}";
+    }
+}
+
+/// <summary>
+/// One aircraft's built-in LED behaviour, declared rather than buried in a lambda, so that the
+/// listener that applies it and the editor that displays it read the same table and cannot
+/// drift apart.
+/// </summary>
+public sealed class AircraftLedDefaults
+{
+    public IReadOnlyList<SignalDefault> Signals { get; init; } = Array.Empty<SignalDefault>();
+
+    public IReadOnlyList<McduLedDefault> McduLeds { get; init; } = Array.Empty<McduLedDefault>();
+
+    /// <summary>
+    /// Signals the listener derives in code because no single control expresses them — an OR of
+    /// three lights, a bitfield off a raw register. The value names what it is worked out from.
+    /// </summary>
+    public IReadOnlyDictionary<FlightDeckSignal, string> ComputedSignals { get; init; } =
+        new Dictionary<FlightDeckSignal, string>();
+
+    /// <summary>MCDU annunciators derived in code, as <see cref="ComputedSignals"/>.</summary>
+    public IReadOnlyDictionary<McduLed, string> ComputedMcduLeds { get; init; } =
+        new Dictionary<McduLed, string>();
+
+    public static readonly AircraftLedDefaults None = new();
+
+    public LedDefaultInfo For(FlightDeckSignal signal)
+    {
+        var direct = Signals.FirstOrDefault(s => s.Signal == signal);
+        if (direct != null) return LedDefaultInfo.From(direct.Controls);
+
+        return ComputedSignals.TryGetValue(signal, out var from)
+            ? LedDefaultInfo.Computed(from)
+            : LedDefaultInfo.None;
+    }
+
+    public LedDefaultInfo For(McduLed led)
+    {
+        var direct = McduLeds.FirstOrDefault(l => l.Led == led);
+        if (direct != null) return LedDefaultInfo.From(direct.Control);
+
+        return ComputedMcduLeds.TryGetValue(led, out var from)
+            ? LedDefaultInfo.Computed(from)
+            : LedDefaultInfo.None;
+    }
+}
+
+/// <summary>
+/// Every aircraft's built-in LED behaviour, in one table. The base listener registers these
+/// on start; the LED editor shows them as each row's starting point, so a user who has bound
+/// nothing still sees what the aircraft is driving, and clearing a binding puts it back.
+/// </summary>
+public static class LedDefaults
+{
+    private static readonly Dictionary<int, AircraftLedDefaults> _byModuleId = new()
+    {
+        // A-10C
+        [5] = new AircraftLedDefaults
+        {
+            Signals = new[]
+            {
+                new SignalDefault(FlightDeckSignal.GearLeftDown, "GEAR_L_SAFE"),
+                new SignalDefault(FlightDeckSignal.GearNoseDown, "GEAR_N_SAFE"),
+                new SignalDefault(FlightDeckSignal.GearRightDown, "GEAR_R_SAFE"),
+                new SignalDefault(FlightDeckSignal.GearWarning, "HANDLE_GEAR_WARNING"),
+            },
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "MASTER_CAUTION"),
+                new McduLedDefault(McduLed.Fm1, "GUN_READY"),
+                new McduLedDefault(McduLed.Fm2, "CANOPY_UNLOCKED"),
+                new McduLedDefault(McduLed.Ind, "NOSEWHEEL_STEERING"),
+            },
+        },
+
+        // AH-64D
+        [46] = new AircraftLedDefaults
+        {
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "PLT_MASTER_CAUTION_L"),
+                new McduLedDefault(McduLed.Ind, "PLT_MASTER_WARNING_L"),
+            },
+        },
+
+        // F/A-18C
+        [20] = new AircraftLedDefaults
+        {
+            Signals = new[]
+            {
+                new SignalDefault(FlightDeckSignal.GearLeftDown, "FLP_LG_LEFT_GEAR_LT"),
+                new SignalDefault(FlightDeckSignal.GearNoseDown, "FLP_LG_NOSE_GEAR_LT"),
+                new SignalDefault(FlightDeckSignal.GearRightDown, "FLP_LG_RIGHT_GEAR_LT"),
+                new SignalDefault(FlightDeckSignal.GearWarning, "LANDING_GEAR_HANDLE_LT"),
+                new SignalDefault(FlightDeckSignal.AutoBrkLoDecel, "FLP_LG_HALF_FLAPS_LT"),
+                new SignalDefault(FlightDeckSignal.AutoBrkMedDecel, "FLP_LG_FULL_FLAPS_LT"),
+            },
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "MASTER_CAUTION_LT"),
+            },
+        },
+
+        // CH-47F
+        [50] = new AircraftLedDefaults
+        {
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "PLT_MASTER_CAUTION_LIGHT"),
+            },
+        },
+
+        // M-2000C — every LED comes off a raw lighting register, so none of them is one control.
+        [27] = new AircraftLedDefaults
+        {
+            ComputedSignals = new Dictionary<FlightDeckSignal, string>
+            {
+                [FlightDeckSignal.GearLeftDown] = "gear configuration bits",
+                [FlightDeckSignal.GearNoseDown] = "gear configuration bits",
+                [FlightDeckSignal.GearRightDown] = "gear configuration bits",
+                [FlightDeckSignal.GearWarning] = "gear lever and configuration bits",
+            },
+            ComputedMcduLeds = new Dictionary<McduLed, string>
+            {
+                [McduLed.Fail] = "PCN light register (UNI)",
+                [McduLed.Fm1] = "PCN light register (ALN)",
+                [McduLed.Fm2] = "PCN light register (SEC)",
+                [McduLed.Fm] = "PCN light register (NDEG)",
+                [McduLed.Ind] = "PCN light register (MIP)",
+                [McduLed.Rdy] = "PCN light register (PRET)",
+            },
+        },
+
+        // F-16C
+        [17] = new AircraftLedDefaults
+        {
+            Signals = new[]
+            {
+                new SignalDefault(FlightDeckSignal.GearLeftDown, "LIGHT_GEAR_L"),
+                new SignalDefault(FlightDeckSignal.GearNoseDown, "LIGHT_GEAR_N"),
+                new SignalDefault(FlightDeckSignal.GearRightDown, "LIGHT_GEAR_R"),
+                new SignalDefault(FlightDeckSignal.GearWarning, "LIGHT_GEAR_WARN"),
+            },
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "LIGHT_MASTER_CAUTION"),
+            },
+        },
+
+        // UH-1H
+        [38] = new AircraftLedDefaults
+        {
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "MASTER_CAUTION_IND"),
+            },
+        },
+
+        // F-14B — the warning lights when any leg reports itself not locked down.
+        [16] = new AircraftLedDefaults
+        {
+            Signals = new[]
+            {
+                new SignalDefault(FlightDeckSignal.GearLeftDown, "PLT_GEAR_L_IND_L"),
+                new SignalDefault(FlightDeckSignal.GearNoseDown, "PLT_GEAR_NOSE_IND_L"),
+                new SignalDefault(FlightDeckSignal.GearRightDown, "PLT_GEAR_R_IND_L"),
+                new SignalDefault(FlightDeckSignal.GearWarning,
+                    "PLT_GEAR_L_OFF_L", "PLT_GEAR_NOSE_OFF_L", "PLT_GEAR_R_OFF_L"),
+            },
+
+        },
+    };
+
+    /// <summary>What <paramref name="descriptor"/>'s aircraft lights on its own.</summary>
+    internal static AircraftLedDefaults For(AircraftDescriptor descriptor) =>
+        _byModuleId.GetValueOrDefault(descriptor.ModuleId, AircraftLedDefaults.None);
+
+    /// <summary>What the aircraft with this registry display name lights on its own.</summary>
+    internal static AircraftLedDefaults ForDisplayName(string displayName)
+    {
+        var descriptor = AircraftRegistry.All.FirstOrDefault(d =>
+            string.Equals(d.DisplayName, displayName, StringComparison.Ordinal));
+
+        return descriptor is null ? AircraftLedDefaults.None : For(descriptor);
+    }
+}

--- a/Aircrafts/UH1H/UH1H_Listener.cs
+++ b/Aircrafts/UH1H/UH1H_Listener.cs
@@ -1,4 +1,4 @@
-using WwDevicesDotNet;
+﻿using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Aircrafts.UH1H;
 
@@ -62,7 +62,7 @@ internal class UH1H_Listener : AircraftListener
             CduDevice.KeyDown += HandleKeyDown;
         }
 
-        RegisterLight("MASTER_CAUTION_IND", v => SetCduLeds(fail: v == 1));
+        // The master caution is declared in LedDefaults.
 
         // ── VHF COMM (ARC-134) ────────────────────────────────────────────
         RegisterUInt("VHFCOMM_PWR", v =>

--- a/Config/LedMapping.cs
+++ b/Config/LedMapping.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+
+namespace WCtrlDcsBiosBridge.Config;
+
+/// <summary>
+/// How a DCS-BIOS value decides whether the bound LED is lit.
+/// </summary>
+public enum LedCondition
+{
+    /// <summary>Lit whenever the value is not zero. Right for every indicator lamp.</summary>
+    NotZero,
+
+    /// <summary>Lit when the value equals <see cref="LedBinding.Value"/>.</summary>
+    Equals,
+
+    /// <summary>Lit when the value is greater than or equal to <see cref="LedBinding.Value"/>.</summary>
+    AtLeast,
+
+    /// <summary>Lit when the value is less than or equal to <see cref="LedBinding.Value"/>.</summary>
+    AtMost,
+}
+
+/// <summary>
+/// One user-defined LED binding: on this aircraft, this LED of this device family follows
+/// this DCS-BIOS control.
+/// </summary>
+public sealed class LedBinding
+{
+    /// <summary>The aircraft's registry display name, e.g. "F/A-18C".</summary>
+    public string Aircraft { get; set; } = string.Empty;
+
+    /// <summary>The device family the LED belongs to.</summary>
+    public LedDeviceFamily Device { get; set; }
+
+    /// <summary>The LED id, as listed by <see cref="LedCatalog.For"/>.</summary>
+    public string Led { get; set; } = string.Empty;
+
+    /// <summary>The DCS-BIOS control identifier driving the LED.</summary>
+    public string Control { get; set; } = string.Empty;
+
+    /// <summary>The test applied to the control's value.</summary>
+    public LedCondition Op { get; set; } = LedCondition.NotZero;
+
+    /// <summary>The threshold <see cref="Op"/> compares against. Ignored for <see cref="LedCondition.NotZero"/>.</summary>
+    public uint Value { get; set; }
+
+    /// <summary>Whether the LED should be lit for <paramref name="value"/>.</summary>
+    public bool IsOn(uint value) => Op switch
+    {
+        LedCondition.NotZero => value != 0,
+        LedCondition.Equals => value == Value,
+        LedCondition.AtLeast => value >= Value,
+        LedCondition.AtMost => value <= Value,
+        _ => false,
+    };
+
+    /// <summary>The (aircraft, device, LED) triple a binding is unique on.</summary>
+    internal (string, LedDeviceFamily, string) Slot =>
+        (Aircraft.ToUpperInvariant(), Device, Led.ToUpperInvariant());
+}
+
+/// <summary>
+/// The contents of ledmappings.json: a flat list, so the file stays readable and shareable
+/// and so an unknown entry can be dropped without disturbing its neighbours.
+/// </summary>
+public sealed class LedMappingFile
+{
+    /// <summary>Schema version, for future migrations.</summary>
+    public int Version { get; set; } = CurrentVersion;
+
+    public List<LedBinding> Bindings { get; set; } = new();
+
+    public const int CurrentVersion = 1;
+
+    /// <summary>The bindings for one aircraft, by registry display name.</summary>
+    public IReadOnlyList<LedBinding> ForAircraft(string aircraftDisplayName) =>
+        Bindings.Where(b => string.Equals(b.Aircraft, aircraftDisplayName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+    /// <summary>
+    /// Drops entries that cannot be applied and collapses duplicates, reporting one message
+    /// per dropped entry. A shared or hand-edited file is expected to contain the odd stale
+    /// binding — after a DCS-BIOS module update, say — and one bad line must never cost the
+    /// user the rest of the file.
+    /// </summary>
+    /// <param name="knownAircraft">Registry display names that exist in this build.</param>
+    public (LedMappingFile Clean, IReadOnlyList<string> Warnings) Sanitize(IEnumerable<string> knownAircraft)
+    {
+        var known = new HashSet<string>(knownAircraft, StringComparer.OrdinalIgnoreCase);
+        var warnings = new List<string>();
+        var kept = new Dictionary<(string, LedDeviceFamily, string), LedBinding>();
+
+        foreach (var binding in Bindings)
+        {
+            if (binding is null) continue;
+
+            if (!known.Contains(binding.Aircraft))
+            {
+                warnings.Add($"Unknown aircraft '{binding.Aircraft}' — binding for LED {binding.Device}/{binding.Led} ignored.");
+                continue;
+            }
+
+            if (LedCatalog.Find(binding.Device, binding.Led) is null)
+            {
+                warnings.Add($"Unknown LED '{binding.Led}' on {binding.Device} — binding for {binding.Aircraft} ignored.");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(binding.Control))
+            {
+                warnings.Add($"No DCS-BIOS control set for {binding.Aircraft} {binding.Device}/{binding.Led} — binding ignored.");
+                continue;
+            }
+
+            binding.Control = binding.Control.Trim();
+
+            // Last one wins: a hand-merged file can name the same LED twice, and silently
+            // keeping the later entry matches what the editor would have produced.
+            if (kept.ContainsKey(binding.Slot))
+                warnings.Add($"Duplicate binding for {binding.Aircraft} {binding.Device}/{binding.Led} — the last one is used.");
+
+            kept[binding.Slot] = binding;
+        }
+
+        return (new LedMappingFile { Version = CurrentVersion, Bindings = kept.Values.ToList() }, warnings);
+    }
+}

--- a/Config/LedMappingStorage.cs
+++ b/Config/LedMappingStorage.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WCtrlDcsBiosBridge.Aircrafts;
+using WCtrlDcsBiosBridge.Common;
+
+namespace WCtrlDcsBiosBridge.Config;
+
+/// <summary>
+/// Reads and writes ledmappings.json. Kept apart from useroptions.json on purpose: a LED
+/// mapping is worth sharing (an "A-10C on the PAP3" file can be posted and dropped in), and
+/// that only works when the file holds nothing else.
+/// </summary>
+public static class LedMappingStorage
+{
+    public const string FileName = "ledmappings.json";
+
+    public static string FilePath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, FileName);
+
+    private static JsonSerializerOptions SerializerOptions => new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true,
+        // Enums as names: the file is meant to be read, edited and shared by hand.
+        Converters = { new JsonStringEnumConverter(allowIntegerValues: false) },
+    };
+
+    /// <summary>
+    /// Loads the mapping file. A missing file is success with an empty mapping — unlike
+    /// useroptions.json this one is optional and is not written until the user binds something.
+    /// </summary>
+    public static Result<LedMappingFile> TryLoad(string? path = null)
+    {
+        var file = path ?? FilePath;
+        try
+        {
+            if (!File.Exists(file))
+                return Result<LedMappingFile>.Success(new LedMappingFile());
+
+            var json = File.ReadAllText(file);
+            var mapping = JsonSerializer.Deserialize<LedMappingFile>(json, SerializerOptions);
+
+            return Result<LedMappingFile>.Success(mapping ?? new LedMappingFile());
+        }
+        catch (Exception ex)
+        {
+            return Result<LedMappingFile>.Failure($"Error loading LED mappings: {ex.Message}");
+        }
+    }
+
+    public static Result<Unit> TrySave(LedMappingFile? mapping, string? path = null)
+    {
+        var file = path ?? FilePath;
+        try
+        {
+            if (mapping is null)
+                return Result<Unit>.Success(Unit.Value);
+
+            var dir = Path.GetDirectoryName(file);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            File.WriteAllText(file, JsonSerializer.Serialize(mapping, SerializerOptions));
+            return Result<Unit>.Success(Unit.Value);
+        }
+        catch (Exception ex)
+        {
+            return Result<Unit>.Failure($"Error saving LED mappings: {ex.Message}");
+        }
+    }
+}
+
+/// <summary>
+/// The mapping the app is currently running on. A static holder rather than a constructor
+/// argument: aircraft listeners are built by twelve factory lambdas that all take
+/// <c>UserOptions</c> only, and the bindings are read in one place — the base listener.
+/// </summary>
+public static class LedMappingStore
+{
+    private static volatile LedMappingFile _current = new();
+
+    /// <summary>The sanitized mapping in force. Never null.</summary>
+    public static LedMappingFile Current => _current;
+
+    /// <summary>Reloads from disk, dropping unusable entries and logging why.</summary>
+    public static void Reload()
+    {
+        var result = LedMappingStorage.TryLoad();
+        if (!result.IsSuccess)
+        {
+            App.Logger.Warn($"LED mappings not loaded: {result.Error}");
+            return;
+        }
+
+        var clean = Apply(result.Value!);
+        App.Logger.Info($"LED mappings loaded: {clean.Bindings.Count} binding(s)");
+    }
+
+    /// <summary>Sanitizes <paramref name="mapping"/>, writes it to disk and adopts it.</summary>
+    public static Result<Unit> Save(LedMappingFile mapping)
+    {
+        var clean = Apply(mapping);
+        var saved = LedMappingStorage.TrySave(clean);
+        if (!saved.IsSuccess) App.Logger.Warn(saved.Error);
+        return saved;
+    }
+
+    /// <summary>The bindings that apply to one aircraft, by registry display name.</summary>
+    public static IReadOnlyList<LedBinding> ForAircraft(string aircraftDisplayName) =>
+        _current.ForAircraft(aircraftDisplayName);
+
+    private static LedMappingFile Apply(LedMappingFile mapping)
+    {
+        var (clean, warnings) = mapping.Sanitize(AircraftRegistry.All.Select(d => d.DisplayName));
+        foreach (var warning in warnings) App.Logger.Warn($"LED mapping: {warning}");
+
+        _current = clean;
+        return clean;
+    }
+}

--- a/Devices/Cdu/CduRenderer.cs
+++ b/Devices/Cdu/CduRenderer.cs
@@ -1,4 +1,4 @@
-using DCS_BIOS.Serialized;
+﻿using DCS_BIOS.Serialized;
 using WwDevicesDotNet;
 
 namespace WCtrlDcsBiosBridge.Devices.Cdu;
@@ -20,6 +20,18 @@ public bool BrightnessDirty { get; set; } = false;
     public bool LedRdy { get; set; }
     public bool LedsDirty { get; set; } = true;
 
+    /// <summary>
+    /// Forgets which annunciators were lit, after the device itself has been blanked. This
+    /// state outlives the listener that wrote it — the same context serves the next aircraft —
+    /// so leaving it claiming a lamp is lit while the hardware is dark would keep the next
+    /// session from lighting it again when the same value comes back.
+    /// </summary>
+    public void ForgetLeds()
+    {
+        LedFail = LedFm1 = LedFm2 = LedFm = LedInd = LedRdy = false;
+        LedsDirty = true;
+    }
+
     public McduFontFile? Font { get; set; }
     public bool FontDirty { get; set; }
 }
@@ -31,6 +43,28 @@ internal sealed class CduRenderer
     public CduRenderer(ICdu device)
     {
         _device = device;
+    }
+
+    /// <summary>
+    /// Pushes the annunciators, if any of them moved. Runs on its own tick, far more often
+    /// than the screen: a flashing caution lamp sampled at 10 Hz blinks visibly slower than
+    /// the one in the cockpit, and this costs nothing on the ticks where nothing changed.
+    /// </summary>
+    public void RenderLeds(CduRenderState state)
+    {
+        lock (state.SyncRoot)
+        {
+            if (!state.LedsDirty) return;
+
+            _device.Leds.Fail = state.LedFail;
+            _device.Leds.Fm1 = state.LedFm1;
+            _device.Leds.Fm2 = state.LedFm2;
+            _device.Leds.Fm = state.LedFm;
+            _device.Leds.Ind = state.LedInd;
+            _device.Leds.Rdy = state.LedRdy;
+            _device.RefreshLeds();
+            state.LedsDirty = false;
+        }
     }
 
     public void Render(Screen source, CduRenderState state)
@@ -55,17 +89,7 @@ internal sealed class CduRenderer
                 state.BrightnessDirty = false;
             }
 
-            if (state.LedsDirty)
-            {
-                _device.Leds.Fail = state.LedFail;
-                _device.Leds.Fm1 = state.LedFm1;
-                _device.Leds.Fm2 = state.LedFm2;
-                _device.Leds.Fm = state.LedFm;
-                _device.Leds.Ind = state.LedInd;
-                _device.Leds.Rdy = state.LedRdy;
-                _device.RefreshLeds();
-                state.LedsDirty = false;
-            }
+            RenderLeds(state);
         }
     }
 
@@ -96,15 +120,26 @@ internal sealed class AircraftCduContext
         remove => Device.KeyDown -= value;
     }
 
-    public void Reset() => Device.Reset();
+    public void Reset()
+    {
+        Device.Reset();
+        lock (State.SyncRoot)
+        {
+            State.ForgetLeds();
+        }
+    }
 
     public void Render(Screen screen) => _renderer.Render(screen, State);
+
+    /// <summary>Pushes the annunciators alone, on the LED tick.</summary>
+    public void RenderLeds() => _renderer.RenderLeds(State);
 
     public void Cleanup()
     {
         lock (State.SyncRoot)
         {
             _renderer.Cleanup();
+            State.ForgetLeds();
         }
     }
 }

--- a/Devices/Frontpanels/FrontpanelHub.cs
+++ b/Devices/Frontpanels/FrontpanelHub.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,7 +16,13 @@ namespace WCtrlDcsBiosBridge.Devices.Frontpanels;
 /// </summary>
 public class FrontpanelHub : IDisposable
 {
-    private const double RenderIntervalMs = 100;
+    // LEDs are rendered at 30 Hz and displays every third tick (~10 Hz). DCS-BIOS exports on
+    // every rendered frame, so the render tick is the only thing quantizing a lamp: at 10 Hz a
+    // flashing caution comes out as a slower, uneven blink that does not match the cockpit.
+    // Displays gain nothing from the extra rate and cost four HID writes a frame, so they keep
+    // the old cadence; LED frames are only sent when they change, which usually means never.
+    private const double LedIntervalMs = 33;
+    private const int DisplayEveryNthTick = 3;
 
     private readonly List<IFrontpanelAdapter> _adapters;
     private readonly List<FrontpanelRenderer> _renderers = new();
@@ -24,6 +30,7 @@ public class FrontpanelHub : IDisposable
     private readonly object _renderLock = new();
 
     private FlightDeckState? _model;
+    private long _tick;
     private readonly bool _manageLighting;
     private bool _disposed;
 
@@ -53,7 +60,7 @@ public class FrontpanelHub : IDisposable
             App.Logger.Warn($"No renderer for frontpanel adapter type: {adapter.GetType().Name} ({adapter.DisplayName})");
         }
 
-        _renderTimer = new Timer(RenderIntervalMs);
+        _renderTimer = new Timer(LedIntervalMs);
         _renderTimer.Elapsed += (_, _) => RenderTick();
     }
 
@@ -116,6 +123,10 @@ public class FrontpanelHub : IDisposable
 
     private void InitializeDevices()
     {
+        // The renderers only send what changed, so anything that blanks the devices behind
+        // their back has to tell them, or the panels stay dark until a value happens to move.
+        foreach (var renderer in _renderers) renderer.Invalidate();
+
         if (!_manageLighting) return;
         lock (_renderLock)
         {
@@ -143,11 +154,16 @@ public class FrontpanelHub : IDisposable
             var model = _model;
             if (model == null) return;
 
+            // A skipped tick must not cost the display its turn, so count the ticks that ran.
+            _tick++;
+            var withDisplay = _tick % DisplayEveryNthTick == 0;
+
             foreach (var renderer in _renderers)
             {
                 try
                 {
-                    renderer.Render(model);
+                    renderer.RenderLeds(model);
+                    if (withDisplay) renderer.RenderDisplay(model);
                 }
                 catch (Exception ex)
                 {

--- a/Devices/Frontpanels/LedCatalog.cs
+++ b/Devices/Frontpanels/LedCatalog.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WCtrlDcsBiosBridge.Aircrafts;
+using WwDevicesDotNet;
+using WwDevicesDotNet.Winctrl.Agp32;
+using WwDevicesDotNet.Winctrl.FcuAndEfis;
+using WwDevicesDotNet.Winctrl.Pap3;
+
+namespace WCtrlDcsBiosBridge.Devices.Frontpanels;
+
+/// <summary>
+/// The LED-carrying device families a user binding can target. PDC-3 is absent
+/// on purpose: it drives brightness only and has no LEDs of its own.
+/// </summary>
+public enum LedDeviceFamily
+{
+    FcuEfis,
+    Pap3,
+    Agp32,
+    Mcdu,
+}
+
+/// <summary>The six MCDU annunciators, as named on the CDU state.</summary>
+public enum McduLed
+{
+    Fail,
+    Fm1,
+    Fm2,
+    Fm,
+    Ind,
+    Rdy,
+}
+
+/// <summary>
+/// One bindable LED on a device family: a stable id for the mapping file, the label
+/// silkscreened on the hardware, and — for frontpanel families — the setter that writes
+/// it into that family's LED object. <see cref="Set"/> is null for
+/// <see cref="LedDeviceFamily.Mcdu"/>, whose LEDs live on the CDU state rather than an
+/// <see cref="IFrontpanelLeds"/>; use <see cref="LedCatalog.ParseMcduLed"/> there.
+/// </summary>
+/// <remarks>
+/// Labels are not translated: they are the legends printed on the panels, which read the
+/// same in every language.
+/// </remarks>
+/// <param name="Signal">
+/// The semantic signal this LED shows when the user has not bound it. Null for a LED no
+/// aircraft drives on its own — the FCU/EFIS and PAP3 legends, which have no equivalent in
+/// the flight deck model and stay dark until somebody binds them.
+/// </param>
+public sealed record LedDescriptor(
+    string Id,
+    string Label,
+    Action<IFrontpanelLeds, bool>? Set = null,
+    FlightDeckSignal? Signal = null);
+
+/// <summary>
+/// What is bindable on each device family. Written out by hand rather than reflected over
+/// the LED classes because the families do not agree on shape — FCU/EFIS and PAP3 expose
+/// bool properties, the AGP32 an enum plus a Set method — and because explicit entries give
+/// stable ids that survive a rename in the device library.
+/// </summary>
+public static class LedCatalog
+{
+    private static LedDescriptor Fcu(string id, string label, Action<FcuEfisLeds, bool> set) =>
+        new(id, label, (leds, on) => { if (leds is FcuEfisLeds l) set(l, on); });
+
+    private static LedDescriptor Pap(string id, string label, Action<Pap3Leds, bool> set) =>
+        new(id, label, (leds, on) => { if (leds is Pap3Leds l) set(l, on); });
+
+    private static LedDescriptor Agp(string id, string label, Agp32State.Agp32Led led, FlightDeckSignal signal) =>
+        new(id, label, (leds, on) => { if (leds is Agp32State.Agp32Leds l) l.Set(led, on); }, signal);
+
+    private static readonly IReadOnlyList<LedDescriptor> _fcuEfis = new[]
+    {
+        Fcu("Loc",       "LOC",       (l, v) => l.Loc = v),
+        Fcu("Ap1",       "AP1",       (l, v) => l.Ap1 = v),
+        Fcu("Ap2",       "AP2",       (l, v) => l.Ap2 = v),
+        Fcu("AThr",      "A/THR",     (l, v) => l.AThr = v),
+        Fcu("Exped",     "EXPED",     (l, v) => l.Exped = v),
+        Fcu("Appr",      "APPR",      (l, v) => l.Appr = v),
+        Fcu("LeftFd",    "FD (L)",    (l, v) => l.LeftFd = v),
+        Fcu("LeftLs",    "LS (L)",    (l, v) => l.LeftLs = v),
+        Fcu("LeftCstr",  "CSTR (L)",  (l, v) => l.LeftCstr = v),
+        Fcu("LeftWpt",   "WPT (L)",   (l, v) => l.LeftWpt = v),
+        Fcu("LeftVorD",  "VOR.D (L)", (l, v) => l.LeftVorD = v),
+        Fcu("LeftNdb",   "NDB (L)",   (l, v) => l.LeftNdb = v),
+        Fcu("LeftArpt",  "ARPT (L)",  (l, v) => l.LeftArpt = v),
+        Fcu("RightFd",   "FD (R)",    (l, v) => l.RightFd = v),
+        Fcu("RightLs",   "LS (R)",    (l, v) => l.RightLs = v),
+        Fcu("RightCstr", "CSTR (R)",  (l, v) => l.RightCstr = v),
+        Fcu("RightWpt",  "WPT (R)",   (l, v) => l.RightWpt = v),
+        Fcu("RightVorD", "VOR.D (R)", (l, v) => l.RightVorD = v),
+        Fcu("RightNdb",  "NDB (R)",   (l, v) => l.RightNdb = v),
+        Fcu("RightArpt", "ARPT (R)",  (l, v) => l.RightArpt = v),
+    };
+
+    private static readonly IReadOnlyList<LedDescriptor> _pap3 = new[]
+    {
+        Pap("N1",      "N1",       (l, v) => l.N1 = v),
+        Pap("Speed",   "SPEED",    (l, v) => l.Speed = v),
+        Pap("Vnav",    "VNAV",     (l, v) => l.Vnav = v),
+        Pap("LvlChg",  "LVL CHG",  (l, v) => l.LvlChg = v),
+        Pap("HdgSel",  "HDG SEL",  (l, v) => l.HdgSel = v),
+        Pap("Lnav",    "LNAV",     (l, v) => l.Lnav = v),
+        Pap("VorLoc",  "VOR LOC",  (l, v) => l.VorLoc = v),
+        Pap("App",     "APP",      (l, v) => l.App = v),
+        Pap("AltHold", "ALT HOLD", (l, v) => l.AltHold = v),
+        Pap("Vs",      "V/S",      (l, v) => l.Vs = v),
+        Pap("CmdA",    "CMD A",    (l, v) => l.CmdA = v),
+        Pap("CwsA",    "CWS A",    (l, v) => l.CwsA = v),
+        Pap("CmdB",    "CMD B",    (l, v) => l.CmdB = v),
+        Pap("CwsB",    "CWS B",    (l, v) => l.CwsB = v),
+        Pap("AtArm",   "A/T ARM",  (l, v) => l.AtArm = v),
+        Pap("FdL",     "FD (L)",   (l, v) => l.FdL = v),
+        Pap("FdR",     "FD (R)",   (l, v) => l.FdR = v),
+    };
+
+    private static readonly IReadOnlyList<LedDescriptor> _agp32 = new[]
+    {
+        Agp("Gear1Unlk",       "GEAR 1 UNLK",        Agp32State.Agp32Led.Gear1Unlk, FlightDeckSignal.GearWarning),
+        Agp("Gear2Unlk",       "GEAR 2 UNLK",        Agp32State.Agp32Led.Gear2Unlk, FlightDeckSignal.GearWarning),
+        Agp("Gear3Unlk",       "GEAR 3 UNLK",        Agp32State.Agp32Led.Gear3Unlk, FlightDeckSignal.GearWarning),
+        Agp("Gear1Down",       "GEAR 1 DOWN",        Agp32State.Agp32Led.Gear1Down, FlightDeckSignal.GearLeftDown),
+        Agp("Gear2Down",       "GEAR 2 DOWN",        Agp32State.Agp32Led.Gear2Down, FlightDeckSignal.GearNoseDown),
+        Agp("Gear3Down",       "GEAR 3 DOWN",        Agp32State.Agp32Led.Gear3Down, FlightDeckSignal.GearRightDown),
+        Agp("GearDownRed",     "GEAR DOWN (red)",    Agp32State.Agp32Led.GearDownRed, FlightDeckSignal.GearWarning),
+        Agp("BrkFanHot",       "BRK FAN HOT",        Agp32State.Agp32Led.BrkFanHot, FlightDeckSignal.BrkFanHot),
+        Agp("BrkFanOn",        "BRK FAN ON",         Agp32State.Agp32Led.BrkFanOn, FlightDeckSignal.BrkFanOn),
+        Agp("AutoBrkLoDecel",  "AUTO BRK LO DECEL",  Agp32State.Agp32Led.AutoBrkLoDecel, FlightDeckSignal.AutoBrkLoDecel),
+        Agp("AutoBrkMedDecel", "AUTO BRK MED DECEL", Agp32State.Agp32Led.AutoBrkMedDecel, FlightDeckSignal.AutoBrkMedDecel),
+        Agp("AutoBrkMaxDecel", "AUTO BRK MAX DECEL", Agp32State.Agp32Led.AutoBrkMaxDecel, FlightDeckSignal.AutoBrkMaxDecel),
+        Agp("AutoBrkLoOn",     "AUTO BRK LO ON",     Agp32State.Agp32Led.AutoBrkLoOn, FlightDeckSignal.AutoBrkLoOn),
+        Agp("AutoBrkMedOn",    "AUTO BRK MED ON",    Agp32State.Agp32Led.AutoBrkMedOn, FlightDeckSignal.AutoBrkMedOn),
+        Agp("AutoBrkMaxOn",    "AUTO BRK MAX ON",    Agp32State.Agp32Led.AutoBrkMaxOn, FlightDeckSignal.AutoBrkMaxOn),
+        Agp("TerrOnNdOn",      "TERR ON ND",         Agp32State.Agp32Led.TerrOnNdOn, FlightDeckSignal.TerrOnNd),
+    };
+
+    private static readonly IReadOnlyList<LedDescriptor> _mcdu = new[]
+    {
+        new LedDescriptor("Fail", "FAIL"),
+        new LedDescriptor("Fm1",  "FM1"),
+        new LedDescriptor("Fm2",  "FM2"),
+        new LedDescriptor("Fm",   "FM"),
+        new LedDescriptor("Ind",  "IND"),
+        new LedDescriptor("Rdy",  "RDY"),
+    };
+
+    /// <summary>The LEDs a user can bind on <paramref name="family"/>, in panel order.</summary>
+    public static IReadOnlyList<LedDescriptor> For(LedDeviceFamily family) => family switch
+    {
+        LedDeviceFamily.FcuEfis => _fcuEfis,
+        LedDeviceFamily.Pap3 => _pap3,
+        LedDeviceFamily.Agp32 => _agp32,
+        LedDeviceFamily.Mcdu => _mcdu,
+        _ => Array.Empty<LedDescriptor>(),
+    };
+
+    /// <summary>Every family that has bindable LEDs.</summary>
+    public static IReadOnlyList<LedDeviceFamily> Families { get; } =
+        Enum.GetValues<LedDeviceFamily>().Where(f => For(f).Count > 0).ToArray();
+
+    /// <summary>Finds a LED by its mapping-file id, or null when the id is unknown.</summary>
+    public static LedDescriptor? Find(LedDeviceFamily family, string ledId) =>
+        For(family).FirstOrDefault(d => string.Equals(d.Id, ledId, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Resolves an MCDU LED id to the enum the listener writes. Returns null for an
+    /// unknown id, which the caller reports rather than throwing.
+    /// </summary>
+    public static McduLed? ParseMcduLed(string ledId) =>
+        Enum.TryParse<McduLed>(ledId, ignoreCase: true, out var led) ? led : null;
+}

--- a/Devices/Frontpanels/Renderers/Agp32Renderer.cs
+++ b/Devices/Frontpanels/Renderers/Agp32Renderer.cs
@@ -11,12 +11,14 @@ internal class Agp32Renderer : FrontpanelRenderer
 {
     private readonly Agp32State _state = new();
 
+    private readonly Agp32State.Agp32Leds _leds = new();
+
     public Agp32Renderer(IReadOnlyList<IFrontpanelAdapter> adapters, bool manageLighting)
         : base(adapters, manageLighting)
     {
     }
 
-    public override void Render(FlightDeckState model)
+    public override void RenderDisplay(FlightDeckState model)
     {
         // Family policy: stay visible even when the cockpit console brightness
         // is at zero — the AGP32 gear lights are useless when dark.
@@ -26,39 +28,16 @@ internal class Agp32Renderer : FrontpanelRenderer
         _state.ClockDisplay = model.ClockUtcTime ?? string.Empty;
         _state.EtDisplay = model.ClockElapsedTime ?? string.Empty;
 
-        var leds = new Agp32State.Agp32Leds();
+        SendDisplay(_state);
+    }
 
-        var left = model.GearLeftDown ?? false;
-        var nose = model.GearNoseDown ?? false;
-        var right = model.GearRightDown ?? false;
-        var warning = model.GearWarning ?? false;
-
-        leds.Set(Agp32State.Agp32Led.Gear1Down, left);
-        leds.Set(Agp32State.Agp32Led.Gear2Down, nose);
-        leds.Set(Agp32State.Agp32Led.Gear3Down, right);
-
-        leds.Set(Agp32State.Agp32Led.BrkFanHot , model.LedBrkFanHot ?? false);
-        leds.Set(Agp32State.Agp32Led.BrkFanOn, model.LedBrkFanOn ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkMedDecel , model.LedAutoBrkMedDecel ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkLoDecel, model.LedAutoBrkLoDecel ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkMaxDecel, model.LedAutoBrkMaxDecel ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkLoOn, model.LedAutoBrkLoOn ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkMedOn, model.LedAutoBrkMedOn ?? false);
-        leds.Set(Agp32State.Agp32Led.AutoBrkMaxOn, model.LedAutoBrkMaxOn ?? false);
-
-        // A single gear-in-transit warning maps to the A320 panel's red UNLK
-        // triangles (lit while a gear disagrees with the lever) plus the
-        // lever's red arrow.
-        leds.Set(Agp32State.Agp32Led.Gear1Unlk, warning);
-        leds.Set(Agp32State.Agp32Led.Gear2Unlk, warning);
-        leds.Set(Agp32State.Agp32Led.Gear3Unlk, warning);
-        leds.Set(Agp32State.Agp32Led.GearDownRed, warning);
-
-        foreach (var adapter in adapters)
-        {
-            if (!adapter.IsConnected) continue;
-            adapter.UpdateDisplay(_state);
-            adapter.UpdateLeds(leds);
-        }
+    public override void RenderLeds(FlightDeckState model)
+    {
+        // Every LED on this panel names the signal it shows (see LedCatalog), so the gear and
+        // autobrake mapping lives there rather than here. One signal can light several: a
+        // single gear-in-transit warning drives the three red UNLK triangles and the lever's
+        // red arrow together.
+        var mask = BuildLeds(model, _leds, LedDeviceFamily.Agp32);
+        if (LedsChanged(mask)) SendLeds(_leds);
     }
 }

--- a/Devices/Frontpanels/Renderers/FcuEfisRenderer.cs
+++ b/Devices/Frontpanels/Renderers/FcuEfisRenderer.cs
@@ -21,7 +21,7 @@ internal class FcuEfisRenderer : FrontpanelRenderer
     {
     }
 
-    public override void Render(FlightDeckState model)
+    public override void RenderDisplay(FlightDeckState model)
     {
         ApplyBrightness(model);
 
@@ -32,11 +32,14 @@ internal class FcuEfisRenderer : FrontpanelRenderer
         _state.LeftBaroPressure = model.BaroPressure;
         _state.RightBaroPressure = model.BaroPressure;
 
-        foreach (var adapter in adapters)
-        {
-            if (!adapter.IsConnected) continue;
-            adapter.UpdateDisplay(_state);
-            adapter.UpdateLeds(_leds);
-        }
+        SendDisplay(_state);
+    }
+
+    public override void RenderLeds(FlightDeckState model)
+    {
+        // As on the PAP3, the Airbus legends have no semantic equivalent: nothing in an A-10C
+        // means "AP1", so this panel lights only what the user bound.
+        var mask = BuildLeds(model, _leds, LedDeviceFamily.FcuEfis);
+        if (LedsChanged(mask)) SendLeds(_leds);
     }
 }

--- a/Devices/Frontpanels/Renderers/FrontpanelRenderer.cs
+++ b/Devices/Frontpanels/Renderers/FrontpanelRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using WwDevicesDotNet;
 using WCtrlDcsBiosBridge.Aircrafts;
 
 namespace WCtrlDcsBiosBridge.Devices.Frontpanels.Renderers;
@@ -8,6 +9,10 @@ namespace WCtrlDcsBiosBridge.Devices.Frontpanels.Renderers;
 /// Translates the semantic <see cref="FlightDeckState"/> to one family of frontpanel
 /// devices. A renderer owns its family's device state/led objects and its lighting
 /// policy; it is created only when at least one adapter of its family is connected.
+///
+/// Displays and LEDs are rendered on separate cadences (see <see cref="FrontpanelHub"/>):
+/// nobody reads an airspeed at 30 Hz, but a flashing caution lamp sampled at 10 Hz comes out
+/// as a slower, uneven blink that does not match the one in the cockpit.
 /// </summary>
 internal abstract class FrontpanelRenderer
 {
@@ -15,6 +20,7 @@ internal abstract class FrontpanelRenderer
     protected readonly bool manageLighting;
 
     private (byte Panel, byte Lcd, byte Led)? _lastBrightness;
+    private ulong? _lastLedMask;
 
     protected FrontpanelRenderer(IReadOnlyList<IFrontpanelAdapter> adapters, bool manageLighting)
     {
@@ -23,10 +29,89 @@ internal abstract class FrontpanelRenderer
     }
 
     /// <summary>
-    /// Pushes the model to every connected adapter of this family.
+    /// Pushes the display side of the model to every connected adapter of this family.
     /// Called from the hub's render timer (single thread).
     /// </summary>
-    public abstract void Render(FlightDeckState model);
+    public abstract void RenderDisplay(FlightDeckState model);
+
+    /// <summary>
+    /// Pushes the LED side of the model. Runs far more often than
+    /// <see cref="RenderDisplay"/> and is expected to send nothing most times it is called.
+    /// </summary>
+    public abstract void RenderLeds(FlightDeckState model);
+
+    /// <summary>
+    /// Forgets what was last sent, so the next render pushes everything again. Call after the
+    /// devices have been reset behind the renderer's back: they are dark, while the caches
+    /// below still describe the frame before the reset, and "unchanged" would keep them dark.
+    /// </summary>
+    public void Invalidate()
+    {
+        _lastBrightness = null;
+        _lastLedMask = null;
+    }
+
+    /// <summary>
+    /// Works out every LED of <paramref name="family"/> and writes it into
+    /// <paramref name="leds"/>: the signal the LED shows by default, overridden by the user's
+    /// binding where they made one. Returns the frame as a bitmask, one bit per catalog entry,
+    /// for <see cref="LedsChanged"/> to compare against the frame before it.
+    /// </summary>
+    protected static ulong BuildLeds(FlightDeckState model, IFrontpanelLeds leds, LedDeviceFamily family)
+    {
+        var catalog = LedCatalog.For(family);
+        var hasUserLeds = model.HasUserLeds;
+        ulong mask = 0;
+
+        for (var i = 0; i < catalog.Count; i++)
+        {
+            var led = catalog[i];
+            if (led.Set == null) continue;
+
+            var on = led.Signal is FlightDeckSignal signal && (model.GetSignal(signal) ?? false);
+
+            // The user's binding is applied last, so it wins on the LEDs they bound and leaves
+            // every other one to the behaviour the aircraft gives it.
+            if (hasUserLeds && model.TryGetUserLed(family, led.Id, out var bound)) on = bound;
+
+            led.Set(leds, on);
+            if (on) mask |= 1UL << i;
+        }
+
+        return mask;
+    }
+
+    /// <summary>
+    /// Whether this LED frame differs from the one last sent. Sending a frame costs one HID
+    /// write per lamp on the panel — the PAP-3 sends seventeen — so at 30 Hz the only
+    /// affordable frame is the one that changed something.
+    /// </summary>
+    protected bool LedsChanged(ulong mask)
+    {
+        if (_lastLedMask == mask) return false;
+        _lastLedMask = mask;
+        return true;
+    }
+
+    /// <summary>Pushes a LED frame to every connected adapter of this family.</summary>
+    protected void SendLeds(IFrontpanelLeds leds)
+    {
+        foreach (var adapter in adapters)
+        {
+            if (!adapter.IsConnected) continue;
+            adapter.UpdateLeds(leds);
+        }
+    }
+
+    /// <summary>Pushes a display frame to every connected adapter of this family.</summary>
+    protected void SendDisplay(IFrontpanelState state)
+    {
+        foreach (var adapter in adapters)
+        {
+            if (!adapter.IsConnected) continue;
+            adapter.UpdateDisplay(state);
+        }
+    }
 
     protected void ApplyBrightness(
         FlightDeckState model,

--- a/Devices/Frontpanels/Renderers/Pap3Renderer.cs
+++ b/Devices/Frontpanels/Renderers/Pap3Renderer.cs
@@ -18,7 +18,7 @@ internal class Pap3Renderer : FrontpanelRenderer
     {
     }
 
-    public override void Render(FlightDeckState model)
+    public override void RenderDisplay(FlightDeckState model)
     {
         ApplyBrightness(model);
 
@@ -29,11 +29,14 @@ internal class Pap3Renderer : FrontpanelRenderer
         _state.PltCourseValue = model.PltCourse;
         _state.CplCourseValue = model.CplCourse;
 
-        foreach (var adapter in adapters)
-        {
-            if (!adapter.IsConnected) continue;
-            adapter.UpdateDisplay(_state);
-            adapter.UpdateLeds(_leds);
-        }
+        SendDisplay(_state);
+    }
+
+    public override void RenderLeds(FlightDeckState model)
+    {
+        // The Boeing autopilot legends have no semantic equivalent — nothing in a DCS module
+        // means "CMD A" — so every lit LED here comes from a user binding.
+        var mask = BuildLeds(model, _leds, LedDeviceFamily.Pap3);
+        if (LedsChanged(mask)) SendLeds(_leds);
     }
 }

--- a/Devices/Frontpanels/Renderers/Pdc3Renderer.cs
+++ b/Devices/Frontpanels/Renderers/Pdc3Renderer.cs
@@ -14,8 +14,13 @@ internal class Pdc3Renderer : FrontpanelRenderer
     {
     }
 
-    public override void Render(FlightDeckState model)
+    public override void RenderDisplay(FlightDeckState model)
     {
         ApplyBrightness(model);
+    }
+
+    public override void RenderLeds(FlightDeckState model)
+    {
+        // Nothing to light on this one.
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -207,6 +207,11 @@
                 </Grid>
             </PivotItem>
 
+            <!-- ══ LEDs ══ -->
+            <PivotItem x:Name="LedMappingPivotItem" x:Uid="LedMappingPivotItem" Header="LEDs">
+                <ui:LedMappingPanel x:Name="LedMappingPanel"/>
+            </PivotItem>
+
             <!-- ══ Help ══ -->
             <PivotItem x:Name="HelpPivotItem" x:Uid="HelpPivotItem" Header="Help">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.UI;
@@ -97,8 +97,13 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
             OptionsPanel.SetLightingManaged(IsLightingManaged);
         };
 
+        LedMappingPanel.MappingChanged += (sender, args) => SaveLedMappings();
+
         LoadConfig();
         LoadUserSettings();
+        LedMappingStore.Reload();
+        LedMappingPanel.Reload();
+        LedMappingPanel.JsonDirectory = config.DcsBiosJsonLocation;
         _currentTheme = userOptions.Theme;
         WindowRoot.RequestedTheme = ThemeManager.CurrentElementTheme;
         UpdateThemeToggleIcon();
@@ -110,6 +115,7 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         StatusControl.Retranslate();
         ConfigPanelControl.Retranslate();
         LogViewerPanelControl.Retranslate();
+        LedMappingPanel.Retranslate();
         OptionsPanel.SetLightingManaged(IsLightingManaged);
 
         _uiSettings.ColorValuesChanged += OnSystemPreferenceChanged;
@@ -409,6 +415,7 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
             if (result == true)
             {
                 config = ConfigPanelControl.Config;
+                LedMappingPanel.JsonDirectory = config.DcsBiosJsonLocation;
                 UpdateState();
 
                 if (IsConfigValid())
@@ -592,6 +599,7 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         _detectedAircraft = descriptor;
         OnPropertyChanged(nameof(DetectedAircraftName));
         OptionsPanel.SetDetectedAircraft(DetectedAircraftName);
+        LedMappingPanel.SetDetectedAircraft(DetectedAircraftName);
     }
 
     private void ResetStartButton()
@@ -645,6 +653,16 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         }
     }
     private void SaveUserSettings() => UserOptionsStorage.Save(userOptions);
+
+    private void SaveLedMappings()
+    {
+        var result = LedMappingStore.Save(LedMappingPanel.BuildMapping());
+        if (!result.IsSuccess)
+        {
+            Logger.Warn($"Failed to save LED mappings: {result.Error}");
+            ShowStatus(Strings.Get("LedMappingSaveFailed"), isError: true);
+        }
+    }
 
     private void ShowStatus(string message, bool isError)
     {
@@ -711,6 +729,7 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
         StatusControl.Retranslate();
         ConfigPanelControl.Retranslate();
         LogViewerPanelControl.Retranslate();
+        LedMappingPanel.Retranslate();
     }
 
     private void UpdateLanguageToggleIcon()
@@ -742,6 +761,7 @@ public partial class MainWindow : Window, IDisposable, INotifyPropertyChanged
     {
         DashboardPivotItem.Header = Strings.Get("DashboardPivotItem");
         ConfigurationPivotItem.Header = Strings.Get("ConfigurationPivotItem");
+        LedMappingPivotItem.Header = Strings.Get("LedMappingPivotItem");
         HelpPivotItem.Header = Strings.Get("HelpPivotItem");
 
         DashboardDescriptionText.Text = Strings.Get("DashboardDescriptionText");

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The **A-10C** drives the full set (flight data, gear LEDs, and the chrono/UTC/ET
 The **F-14B** drives the AGP32 gear lights and clock. The **OH-58D** drives the AGP32 UTC clock.
 See each aircraft's page for specifics.
 
+**LEDs** are yours to assign: on the **LEDs** tab, bind any DCS-BIOS indicator of the aircraft
+you fly to any LED on your panels — the FCU/EFIS and PAP3 legends (AP1, CMD A, …) light up only
+this way. See [LED mapping](docs/LED-Mapping.md).
+
 ## Installation
 
 ### DCS-BIOS Setup

--- a/Strings/de-de/Resources.resw
+++ b/Strings/de-de/Resources.resw
@@ -228,4 +228,20 @@
   <data name="ShowDedKeyLabel" xml:space="preserve"><value>Taste DED anzeigen:</value></data>
   <data name="ShowNavKeyLabel" xml:space="preserve"><value>Taste NAV anzeigen:</value></data>
   <data name="ShowRwrKeyLabel" xml:space="preserve"><value>Taste RWR anzeigen:</value></data>
+  <!-- LedMappingPanel -->
+  <data name="LedMappingPivotItem" xml:space="preserve"><value>LEDs</value></data>
+  <data name="LedMappingHeader" xml:space="preserve"><value>LED-ZUORDNUNG</value></data>
+  <data name="LedMappingIntro" xml:space="preserve"><value>Wählen Sie ein Flugzeug und ein Panel und verbinden Sie eine beliebige DCS-BIOS-Anzeige mit einer LED. Ihre Zuordnungen überschreiben die eingebauten; leer gelassene LEDs behalten ihr Standardverhalten.</value></data>
+  <data name="LedMappingAircraftLabel" xml:space="preserve"><value>Flugzeug:</value></data>
+  <data name="LedMappingDeviceLabel" xml:space="preserve"><value>Panel:</value></data>
+  <data name="LedMappingAdvancedOption" xml:space="preserve"><value>Alle Ganzzahl-Ausgänge anzeigen</value></data>
+  <data name="LedMappingLedHeader" xml:space="preserve"><value>LED</value></data>
+  <data name="LedMappingControlHeader" xml:space="preserve"><value>DCS-BIOS-Steuerelement</value></data>
+  <data name="LedMappingInUseBadge" xml:space="preserve"><value>In Benutzung — Bridge stoppen, um zu ändern</value></data>
+  <data name="LedMappingRestartHint" xml:space="preserve"><value>Änderungen gelten ab dem nächsten Start der Bridge.</value></data>
+  <data name="LedMappingNoControls" xml:space="preserve"><value>Für dieses Flugzeug konnten keine DCS-BIOS-Steuerelemente gelesen werden. Prüfen Sie den DCS-BIOS-JSON-Pfad in der Konfiguration.</value></data>
+  <data name="LedMappingNoLamps" xml:space="preserve"><value>Dieses Modul deklariert keine Anzeigelampen, daher werden alle Ganzzahl-Ausgänge aufgelistet.</value></data>
+  <data name="LedMappingSaveFailed" xml:space="preserve"><value>Die LED-Zuordnungsdatei konnte nicht gespeichert werden.</value></data>
+  <data name="LedMappingBuiltInFormat" xml:space="preserve"><value>{0} (eingebaut)</value></data>
+  <data name="LedMappingComputedFormat" xml:space="preserve"><value>eingebaut, aus {0}</value></data>
 </root>

--- a/Strings/en-us/Resources.resw
+++ b/Strings/en-us/Resources.resw
@@ -228,4 +228,20 @@
   <data name="ShowDedKeyLabel" xml:space="preserve"><value>Show DED Key:</value></data>
   <data name="ShowNavKeyLabel" xml:space="preserve"><value>Show NAV Key:</value></data>
   <data name="ShowRwrKeyLabel" xml:space="preserve"><value>Show RWR Key:</value></data>
+  <!-- LedMappingPanel -->
+  <data name="LedMappingPivotItem" xml:space="preserve"><value>LEDs</value></data>
+  <data name="LedMappingHeader" xml:space="preserve"><value>LED MAPPING</value></data>
+  <data name="LedMappingIntro" xml:space="preserve"><value>Pick an aircraft and a panel, then bind any DCS-BIOS indicator to a LED. Your bindings override the built-in ones; LEDs you leave empty keep their default behaviour.</value></data>
+  <data name="LedMappingAircraftLabel" xml:space="preserve"><value>Aircraft:</value></data>
+  <data name="LedMappingDeviceLabel" xml:space="preserve"><value>Panel:</value></data>
+  <data name="LedMappingAdvancedOption" xml:space="preserve"><value>Show all integer outputs</value></data>
+  <data name="LedMappingLedHeader" xml:space="preserve"><value>LED</value></data>
+  <data name="LedMappingControlHeader" xml:space="preserve"><value>DCS-BIOS control</value></data>
+  <data name="LedMappingInUseBadge" xml:space="preserve"><value>In use — stop the bridge to change it</value></data>
+  <data name="LedMappingRestartHint" xml:space="preserve"><value>Changes apply the next time the bridge starts.</value></data>
+  <data name="LedMappingNoControls" xml:space="preserve"><value>No DCS-BIOS controls could be read for this aircraft. Check the DCS-BIOS JSON location in Configuration.</value></data>
+  <data name="LedMappingNoLamps" xml:space="preserve"><value>This module declares no indicator lamp, so every integer output is listed.</value></data>
+  <data name="LedMappingSaveFailed" xml:space="preserve"><value>Could not save the LED mapping file.</value></data>
+  <data name="LedMappingBuiltInFormat" xml:space="preserve"><value>{0} (built-in)</value></data>
+  <data name="LedMappingComputedFormat" xml:space="preserve"><value>built-in, from {0}</value></data>
 </root>

--- a/Strings/es-es/Resources.resw
+++ b/Strings/es-es/Resources.resw
@@ -228,4 +228,20 @@
   <data name="ShowDedKeyLabel" xml:space="preserve"><value>Tecla Mostrar DED:</value></data>
   <data name="ShowNavKeyLabel" xml:space="preserve"><value>Tecla Mostrar NAV:</value></data>
   <data name="ShowRwrKeyLabel" xml:space="preserve"><value>Tecla Mostrar RWR:</value></data>
+  <!-- LedMappingPanel -->
+  <data name="LedMappingPivotItem" xml:space="preserve"><value>LEDs</value></data>
+  <data name="LedMappingHeader" xml:space="preserve"><value>ASIGNACIÓN DE LEDS</value></data>
+  <data name="LedMappingIntro" xml:space="preserve"><value>Elija una aeronave y un panel, y asocie cualquier indicador de DCS-BIOS a un LED. Sus asociaciones sustituyen a las integradas; los LEDs que deje vacíos conservan su comportamiento por defecto.</value></data>
+  <data name="LedMappingAircraftLabel" xml:space="preserve"><value>Aeronave:</value></data>
+  <data name="LedMappingDeviceLabel" xml:space="preserve"><value>Panel:</value></data>
+  <data name="LedMappingAdvancedOption" xml:space="preserve"><value>Mostrar todas las salidas enteras</value></data>
+  <data name="LedMappingLedHeader" xml:space="preserve"><value>LED</value></data>
+  <data name="LedMappingControlHeader" xml:space="preserve"><value>Control DCS-BIOS</value></data>
+  <data name="LedMappingInUseBadge" xml:space="preserve"><value>En uso — detenga el puente para cambiarlo</value></data>
+  <data name="LedMappingRestartHint" xml:space="preserve"><value>Los cambios se aplican al iniciar el puente la próxima vez.</value></data>
+  <data name="LedMappingNoControls" xml:space="preserve"><value>No se pudieron leer controles DCS-BIOS para esta aeronave. Compruebe la ubicación de los JSON de DCS-BIOS en Configuración.</value></data>
+  <data name="LedMappingNoLamps" xml:space="preserve"><value>Este módulo no declara ningún piloto indicador, por lo que se listan todas las salidas enteras.</value></data>
+  <data name="LedMappingSaveFailed" xml:space="preserve"><value>No se pudo guardar el archivo de asignación de LEDs.</value></data>
+  <data name="LedMappingBuiltInFormat" xml:space="preserve"><value>{0} (integrado)</value></data>
+  <data name="LedMappingComputedFormat" xml:space="preserve"><value>integrado, a partir de {0}</value></data>
 </root>

--- a/Strings/fr-fr/Resources.resw
+++ b/Strings/fr-fr/Resources.resw
@@ -228,4 +228,20 @@
   <data name="ShowDedKeyLabel" xml:space="preserve"><value>Touche Afficher DED :</value></data>
   <data name="ShowNavKeyLabel" xml:space="preserve"><value>Touche Afficher NAV :</value></data>
   <data name="ShowRwrKeyLabel" xml:space="preserve"><value>Touche Afficher RWR :</value></data>
+  <!-- LedMappingPanel -->
+  <data name="LedMappingPivotItem" xml:space="preserve"><value>LEDs</value></data>
+  <data name="LedMappingHeader" xml:space="preserve"><value>AFFECTATION DES LEDS</value></data>
+  <data name="LedMappingIntro" xml:space="preserve"><value>Choisissez un appareil et un panneau, puis associez n'importe quel indicateur DCS-BIOS à une LED. Vos associations remplacent celles d'origine ; les LEDs laissées vides gardent leur comportement par défaut.</value></data>
+  <data name="LedMappingAircraftLabel" xml:space="preserve"><value>Appareil :</value></data>
+  <data name="LedMappingDeviceLabel" xml:space="preserve"><value>Panneau :</value></data>
+  <data name="LedMappingAdvancedOption" xml:space="preserve"><value>Afficher toutes les sorties entières</value></data>
+  <data name="LedMappingLedHeader" xml:space="preserve"><value>LED</value></data>
+  <data name="LedMappingControlHeader" xml:space="preserve"><value>Contrôle DCS-BIOS</value></data>
+  <data name="LedMappingInUseBadge" xml:space="preserve"><value>En cours d'utilisation — arrêtez le pont pour modifier</value></data>
+  <data name="LedMappingRestartHint" xml:space="preserve"><value>Les modifications s'appliquent au prochain démarrage du pont.</value></data>
+  <data name="LedMappingNoControls" xml:space="preserve"><value>Aucun contrôle DCS-BIOS n'a pu être lu pour cet appareil. Vérifiez l'emplacement des fichiers JSON DCS-BIOS dans Configuration.</value></data>
+  <data name="LedMappingNoLamps" xml:space="preserve"><value>Ce module ne déclare aucun voyant : toutes les sorties entières sont listées.</value></data>
+  <data name="LedMappingSaveFailed" xml:space="preserve"><value>Impossible d'enregistrer le fichier d'affectation des LEDs.</value></data>
+  <data name="LedMappingBuiltInFormat" xml:space="preserve"><value>{0} (d'origine)</value></data>
+  <data name="LedMappingComputedFormat" xml:space="preserve"><value>d'origine, d'après {0}</value></data>
 </root>

--- a/Tests/CduLedStateTests.cs
+++ b/Tests/CduLedStateTests.cs
@@ -1,0 +1,44 @@
+using WCtrlDcsBiosBridge.Devices.Cdu;
+using Xunit;
+
+namespace WCtrlDcsBiosBridge.Tests;
+
+/// <summary>
+/// The CDU render state outlives the listener that writes it — one context serves every
+/// aircraft the panel is used for — and LEDs are only pushed to the device when the state
+/// says they changed. So blanking the hardware has to blank the state with it.
+/// </summary>
+public class CduLedStateTests
+{
+    [Fact]
+    public void ForgetLeds_ClearsEveryAnnunciatorAndAsksForAPush()
+    {
+        var state = new CduRenderState
+        {
+            LedFail = true,
+            LedFm1 = true,
+            LedFm2 = true,
+            LedFm = true,
+            LedInd = true,
+            LedRdy = true,
+            LedsDirty = false,
+        };
+
+        state.ForgetLeds();
+
+        Assert.False(state.LedFail);
+        Assert.False(state.LedFm1);
+        Assert.False(state.LedFm2);
+        Assert.False(state.LedFm);
+        Assert.False(state.LedInd);
+        Assert.False(state.LedRdy);
+
+        // Without this, a device blanked behind the state's back stays blank until some value
+        // happens to change.
+        Assert.True(state.LedsDirty);
+    }
+
+    [Fact]
+    public void AFreshStateAsksForAPush() =>
+        Assert.True(new CduRenderState().LedsDirty);
+}

--- a/Tests/DcsBiosControlCatalogTests.cs
+++ b/Tests/DcsBiosControlCatalogTests.cs
@@ -1,0 +1,134 @@
+using DCS_BIOS.ControlLocator;
+using WCtrlDcsBiosBridge.UI;
+using Xunit;
+
+namespace WCtrlDcsBiosBridge.Tests;
+
+/// <summary>
+/// Covers the list the LED editor offers: which of a module's controls can drive a LED, and
+/// which of those the picker shows. The JSON fixture is shaped like a DCS-BIOS doc file, so
+/// this also pins down that the reader gives us the fields the filter depends on —
+/// control_type, the integer output and its max_value.
+/// </summary>
+public class DcsBiosControlCatalogTests
+{
+    private const string ModuleJson = """
+    {
+      "Lights": {
+        "MASTER_CAUTION_LT": {
+          "category": "Lights",
+          "control_type": "led",
+          "description": "Master Caution Light",
+          "identifier": "MASTER_CAUTION_LT",
+          "inputs": [],
+          "outputs": [
+            { "address": 100, "description": "Master Caution", "mask": 1, "max_value": 1, "shift_by": 0, "suffix": "", "type": "integer" }
+          ]
+        }
+      },
+      "Gear": {
+        "GEAR_LEVER": {
+          "category": "Gear",
+          "control_type": "3_position_switch",
+          "description": "Gear Lever",
+          "identifier": "GEAR_LEVER",
+          "inputs": [],
+          "outputs": [
+            { "address": 104, "description": "Gear Lever", "mask": 3, "max_value": 2, "shift_by": 0, "suffix": "", "type": "integer" }
+          ]
+        }
+      },
+      "CDU": {
+        "CDU_LINE0": {
+          "category": "CDU",
+          "control_type": "display",
+          "description": "CDU Line 0",
+          "identifier": "CDU_LINE0",
+          "inputs": [],
+          "outputs": [
+            { "address": 200, "description": "CDU Line 0", "max_length": 24, "suffix": "", "type": "string" }
+          ]
+        }
+      }
+    }
+    """;
+
+    /// <summary>Writes the fixture into a directory the control locator can read.</summary>
+    private static string WriteModule(string fileName)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"dcsbios-json-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), ModuleJson);
+        return dir;
+    }
+
+    [Fact]
+    public void ReadsAModuleJsonIntoTheBindableList()
+    {
+        var fileName = $"TestModule-{Guid.NewGuid():N}.json";
+        var dir = WriteModule(fileName);
+
+        try
+        {
+            DCSBIOSControlLocator.JSONDirectory = dir;
+            var controls = DCSBIOSControlLocator.GetModuleControlsFromJson(fileName, onlyDirectResult: true);
+
+            var bindable = DcsBiosControlCatalog.Bindable(controls);
+
+            // The string-output display is not bindable; the lamp and the switch are.
+            Assert.Equal(2, bindable.Count);
+            Assert.DoesNotContain(bindable, c => c.Identifier == "CDU_LINE0");
+
+            var lamp = Assert.Single(bindable, c => c.Identifier == "MASTER_CAUTION_LT");
+            Assert.True(lamp.IsLamp);
+            Assert.False(lamp.NeedsCondition);
+            Assert.Equal("Master Caution Light (MASTER_CAUTION_LT)", lamp.Display);
+
+            var lever = Assert.Single(bindable, c => c.Identifier == "GEAR_LEVER");
+            Assert.False(lever.IsLamp);
+            Assert.True(lever.NeedsCondition);
+            Assert.Equal(2, lever.MaxValue);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NullControlList_GivesAnEmptyCatalog() =>
+        Assert.Empty(DcsBiosControlCatalog.Bindable(null));
+
+    [Fact]
+    public void Visible_ShowsOnlyLampsByDefault()
+    {
+        var all = new[] { Lamp("A"), Switch("B") };
+
+        var visible = DcsBiosControlCatalog.Visible(all, showEverything: false);
+
+        Assert.Equal("A", Assert.Single(visible).Identifier);
+    }
+
+    [Fact]
+    public void Visible_ShowsEverythingWhenAsked()
+    {
+        var all = new[] { Lamp("A"), Switch("B") };
+
+        Assert.Equal(2, DcsBiosControlCatalog.Visible(all, showEverything: true).Count);
+    }
+
+    [Fact]
+    public void Visible_FallsBackToEverythingWhenTheModuleDeclaresNoLamp()
+    {
+        // Not every module classifies its indicators as control_type "led"; an empty picker
+        // would read as a broken app rather than as a filter doing its job.
+        var all = new[] { Switch("A"), Switch("B") };
+
+        Assert.Equal(2, DcsBiosControlCatalog.Visible(all, showEverything: false).Count);
+        Assert.False(DcsBiosControlCatalog.HasLamps(all));
+    }
+
+    private static ControlChoice Lamp(string id) => new(id, id, "Lights", MaxValue: 1, IsLamp: true);
+
+    private static ControlChoice Switch(string id) => new(id, id, "Systems", MaxValue: 2, IsLamp: false);
+}

--- a/Tests/LedDefaultsTests.cs
+++ b/Tests/LedDefaultsTests.cs
@@ -1,0 +1,304 @@
+using WCtrlDcsBiosBridge.Aircrafts;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+using WCtrlDcsBiosBridge.Devices.Frontpanels.Renderers;
+using WwDevicesDotNet;
+using WwDevicesDotNet.Winctrl.Agp32;
+using Xunit;
+
+namespace WCtrlDcsBiosBridge.Tests;
+
+/// <summary>
+/// Covers the built-in LED behaviour now that it is declared rather than written out in each
+/// listener: that every declaration reaches a real LED, that the panel applies it, and that
+/// the editor can describe it for an aircraft nobody is flying.
+/// </summary>
+public class LedDefaultsTests
+{
+    /// <summary>Reaches the renderer's protected members the way a real renderer does.</summary>
+    private sealed class TestRenderer : FrontpanelRenderer
+    {
+        public TestRenderer() : base(new List<IFrontpanelAdapter>(), manageLighting: false) { }
+
+        public override void RenderDisplay(FlightDeckState model) { }
+
+        public override void RenderLeds(FlightDeckState model) { }
+
+        public ulong Build(FlightDeckState model, IFrontpanelLeds leds, LedDeviceFamily family) =>
+            BuildLeds(model, leds, family);
+
+        public bool Changed(ulong mask) => LedsChanged(mask);
+    }
+
+    private static IEnumerable<AircraftDescriptor> Aircraft => AircraftRegistry.All;
+
+    private static List<string> LitAgp32(Agp32State.Agp32Leds leds) =>
+        leds.States.Where(s => s.Value).Select(s => s.Key.ToString()).OrderBy(s => s).ToList();
+
+    // ── The declarations themselves ──────────────────────────────────────────
+
+    [Fact]
+    public void EveryDeclaredSignalIsShownBySomeLed()
+    {
+        var shown = LedCatalog.Families
+            .SelectMany(f => LedCatalog.For(f))
+            .Select(d => d.Signal)
+            .OfType<FlightDeckSignal>()
+            .ToHashSet();
+
+        foreach (var descriptor in Aircraft)
+        {
+            var defaults = LedDefaults.For(descriptor);
+            foreach (var signal in defaults.Signals)
+            {
+                Assert.True(shown.Contains(signal.Signal),
+                    $"{descriptor.DisplayName} declares {signal.Signal}, which no LED shows");
+            }
+        }
+    }
+
+    [Fact]
+    public void NoAircraftDeclaresTheSameSignalTwice()
+    {
+        foreach (var descriptor in Aircraft)
+        {
+            var defaults = LedDefaults.For(descriptor);
+            var signals = defaults.Signals.Select(s => s.Signal).ToList();
+
+            Assert.Equal(signals.Count, signals.Distinct().Count());
+
+            // A signal is either read off one control or worked out in code, never both:
+            // the editor would have to choose which of the two to report.
+            Assert.Empty(signals.Intersect(defaults.ComputedSignals.Keys));
+
+            var leds = defaults.McduLeds.Select(l => l.Led).ToList();
+            Assert.Equal(leds.Count, leds.Distinct().Count());
+            Assert.Empty(leds.Intersect(defaults.ComputedMcduLeds.Keys));
+        }
+    }
+
+    [Fact]
+    public void EveryDeclaredControlIsNamed()
+    {
+        foreach (var descriptor in Aircraft)
+        {
+            var defaults = LedDefaults.For(descriptor);
+            Assert.All(defaults.Signals, s =>
+            {
+                Assert.NotEmpty(s.Controls);
+                Assert.All(s.Controls, c => Assert.False(string.IsNullOrWhiteSpace(c)));
+            });
+            Assert.All(defaults.McduLeds, l => Assert.False(string.IsNullOrWhiteSpace(l.Control)));
+        }
+    }
+
+    [Fact]
+    public void ADirectDefaultReportsItsControl()
+    {
+        var info = LedDefaults.ForDisplayName("A-10C").For(FlightDeckSignal.GearLeftDown);
+
+        Assert.Equal("GEAR_L_SAFE", Assert.Single(info.Controls!));
+        Assert.Equal("GEAR_L_SAFE", info.Describe());
+        Assert.Null(info.ComputedFrom);
+        Assert.True(info.Exists);
+    }
+
+    [Fact]
+    public void ASignalCanBeDeclaredFromSeveralControls()
+    {
+        // The F-14's gear warning lights when any of three OFF lights does.
+        var info = LedDefaults.ForDisplayName("F-14B").For(FlightDeckSignal.GearWarning);
+
+        Assert.Equal(3, info.Controls!.Count);
+        Assert.Contains("PLT_GEAR_L_OFF_L", info.Controls);
+        Assert.Null(info.ComputedFrom);
+
+        // The placeholder has to stay short, so it names one and counts the rest.
+        Assert.Equal("PLT_GEAR_L_OFF_L +2", info.Describe());
+    }
+
+    [Fact]
+    public void AComputedDefaultReportsWhatItIsWorkedOutFrom()
+    {
+        // The M-2000C reads its lamps out of a raw lighting register: there is no control id
+        // to name, which is what makes a written description honest there and nowhere else.
+        var info = LedDefaults.ForDisplayName("M-2000C").For(FlightDeckSignal.GearWarning);
+
+        Assert.Null(info.Controls);
+        Assert.NotNull(info.ComputedFrom);
+        Assert.True(info.Exists);
+    }
+
+    [Fact]
+    public void AnIdleLedReportsNothing()
+    {
+        // Nothing drives the A-10C's brake-fan lights, so that row starts empty.
+        Assert.False(LedDefaults.ForDisplayName("A-10C").For(FlightDeckSignal.BrkFanOn).Exists);
+    }
+
+    [Fact]
+    public void AnUnknownAircraftHasNoDefaults() =>
+        Assert.Empty(LedDefaults.ForDisplayName("Su-27").Signals);
+
+    [Fact]
+    public void McduDefaultsAreDeclaredForTheAircraftThatHadThem()
+    {
+        Assert.Equal("MASTER_CAUTION", LedDefaults.ForDisplayName("A-10C").For(McduLed.Fail).Describe());
+        Assert.Equal("LIGHT_MASTER_CAUTION", LedDefaults.ForDisplayName("F-16C").For(McduLed.Fail).Describe());
+        Assert.Equal("MASTER_CAUTION_LT", LedDefaults.ForDisplayName("F/A-18C").For(McduLed.Fail).Describe());
+        Assert.Equal("MASTER_CAUTION_IND", LedDefaults.ForDisplayName("UH-1H").For(McduLed.Fail).Describe());
+
+        // The M-2000C reads its annunciators out of a register, so it declares them computed.
+        Assert.NotNull(LedDefaults.ForDisplayName("M-2000C").For(McduLed.Rdy).ComputedFrom);
+    }
+
+    // ── Applying them ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OneWarningSignalLightsAllFourWarningLeds()
+    {
+        var model = new FlightDeckState();
+        model.SetSignal(FlightDeckSignal.GearWarning, true);
+        var leds = new Agp32State.Agp32Leds();
+
+        new TestRenderer().Build(model, leds, LedDeviceFamily.Agp32);
+
+        Assert.Equal(
+            new[] { "Gear1Unlk", "Gear2Unlk", "Gear3Unlk", "GearDownRed" }.OrderBy(s => s),
+            LitAgp32(leds));
+    }
+
+    [Fact]
+    public void EachGearSignalLightsItsOwnLed()
+    {
+        var model = new FlightDeckState();
+        model.SetSignal(FlightDeckSignal.GearLeftDown, true);
+        model.SetSignal(FlightDeckSignal.GearRightDown, true);
+        var leds = new Agp32State.Agp32Leds();
+
+        new TestRenderer().Build(model, leds, LedDeviceFamily.Agp32);
+
+        Assert.Equal(new[] { "Gear1Down", "Gear3Down" }, LitAgp32(leds));
+    }
+
+    [Fact]
+    public void ASignalTheAircraftDoesNotPublishLeavesItsLedOff()
+    {
+        var leds = new Agp32State.Agp32Leds();
+
+        new TestRenderer().Build(new FlightDeckState(), leds, LedDeviceFamily.Agp32);
+
+        Assert.Empty(LitAgp32(leds));
+    }
+
+    [Fact]
+    public void AUserBindingOverridesTheBuiltInOnThatLedAlone()
+    {
+        var model = new FlightDeckState();
+        model.SetSignal(FlightDeckSignal.GearLeftDown, true);
+        model.SetSignal(FlightDeckSignal.GearNoseDown, true);
+        model.SetUserLed(LedDeviceFamily.Agp32, "Gear1Down", false);
+        model.SetUserLed(LedDeviceFamily.Agp32, "TerrOnNdOn", true);
+
+        var leds = new Agp32State.Agp32Leds();
+        new TestRenderer().Build(model, leds, LedDeviceFamily.Agp32);
+
+        // Gear1Down was taken over and forced off; the nose light keeps its built-in behaviour.
+        Assert.Equal(new[] { "Gear2Down", "TerrOnNdOn" }, LitAgp32(leds));
+    }
+
+    [Fact]
+    public void PanelsWithNoBuiltInBehaviourStayDarkUntilBound()
+    {
+        foreach (var family in new[] { LedDeviceFamily.FcuEfis, LedDeviceFamily.Pap3 })
+            Assert.All(LedCatalog.For(family), d => Assert.Null(d.Signal));
+
+        Assert.All(LedCatalog.For(LedDeviceFamily.Agp32), d => Assert.NotNull(d.Signal));
+    }
+
+    // ── Only sending what changed ────────────────────────────────────────────
+
+    [Fact]
+    public void TheFirstFrameIsAlwaysSent()
+    {
+        // Nothing lit is still a frame the panel has not been told about.
+        Assert.True(new TestRenderer().Changed(0));
+    }
+
+    [Fact]
+    public void AnUnchangedFrameIsNotResent()
+    {
+        var renderer = new TestRenderer();
+
+        Assert.True(renderer.Changed(0b0101));
+        Assert.False(renderer.Changed(0b0101));
+        Assert.False(renderer.Changed(0b0101));
+    }
+
+    [Fact]
+    public void AChangedFrameIsSent()
+    {
+        var renderer = new TestRenderer();
+        renderer.Changed(0b0101);
+
+        Assert.True(renderer.Changed(0b0111));
+        Assert.False(renderer.Changed(0b0111));
+
+        // Including going back to a frame sent earlier — the panel shows the latest one.
+        Assert.True(renderer.Changed(0b0101));
+    }
+
+    [Fact]
+    public void InvalidateForcesTheNextFrameOut()
+    {
+        var renderer = new TestRenderer();
+        renderer.Changed(0b0101);
+        Assert.False(renderer.Changed(0b0101));
+
+        // Resetting the devices blanks them behind the renderer's back; without this the
+        // panel would stay dark until some lamp happened to move.
+        renderer.Invalidate();
+        Assert.True(renderer.Changed(0b0101));
+    }
+
+    [Fact]
+    public void TheMaskFollowsTheLitLeds()
+    {
+        var model = new FlightDeckState();
+        var renderer = new TestRenderer();
+        var leds = new Agp32State.Agp32Leds();
+
+        var dark = renderer.Build(model, leds, LedDeviceFamily.Agp32);
+        Assert.Equal(0UL, dark);
+
+        model.SetSignal(FlightDeckSignal.GearWarning, true);
+        var warning = renderer.Build(model, leds, LedDeviceFamily.Agp32);
+        Assert.NotEqual(dark, warning);
+
+        // Same state, same mask — this is what stops the frame being resent thirty times a
+        // second.
+        Assert.Equal(warning, renderer.Build(model, leds, LedDeviceFamily.Agp32));
+    }
+
+    [Fact]
+    public void EveryLedOfAFamilyFitsInTheMask()
+    {
+        // One bit per catalog entry, so a family may not outgrow a ulong.
+        Assert.All(LedCatalog.Families, f => Assert.True(LedCatalog.For(f).Count <= 64));
+    }
+
+    [Fact]
+    public void EverySignalCanBeWrittenAndReadBack()
+    {
+        foreach (var signal in Enum.GetValues<FlightDeckSignal>())
+        {
+            var model = new FlightDeckState();
+            Assert.Null(model.GetSignal(signal));
+
+            model.SetSignal(signal, true);
+            Assert.True(model.GetSignal(signal));
+
+            model.SetSignal(signal, false);
+            Assert.False(model.GetSignal(signal));
+        }
+    }
+}

--- a/Tests/LedMappingTests.cs
+++ b/Tests/LedMappingTests.cs
@@ -1,0 +1,304 @@
+using System.Reflection;
+using WCtrlDcsBiosBridge.Config;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+using WwDevicesDotNet;
+using WwDevicesDotNet.Winctrl.Agp32;
+using WwDevicesDotNet.Winctrl.FcuAndEfis;
+using WwDevicesDotNet.Winctrl.Pap3;
+using Xunit;
+
+namespace WCtrlDcsBiosBridge.Tests;
+
+/// <summary>
+/// Covers the pure half of the user LED mapping: how a DCS-BIOS value decides that a LED is
+/// lit, what survives loading a file someone else wrote, and whether the catalog each editor
+/// row is built from actually reaches distinct hardware LEDs.
+/// </summary>
+public class LedMappingTests
+{
+    private static readonly string[] KnownAircraft = { "A-10C", "F/A-18C" };
+
+    private static LedBinding Binding(
+        string aircraft = "A-10C",
+        LedDeviceFamily device = LedDeviceFamily.FcuEfis,
+        string led = "Ap1",
+        string control = "MASTER_CAUTION",
+        LedCondition op = LedCondition.NotZero,
+        uint value = 0) =>
+        new() { Aircraft = aircraft, Device = device, Led = led, Control = control, Op = op, Value = value };
+
+    // ── Conditions ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0u, false)]
+    [InlineData(1u, true)]
+    [InlineData(65535u, true)]
+    public void NotZero_LightsOnAnyNonZeroValue(uint value, bool expected) =>
+        Assert.Equal(expected, Binding(op: LedCondition.NotZero).IsOn(value));
+
+    [Theory]
+    [InlineData(1u, false)]
+    [InlineData(2u, true)]
+    [InlineData(3u, false)]
+    public void Equals_LightsOnlyOnTheThreshold(uint value, bool expected) =>
+        Assert.Equal(expected, Binding(op: LedCondition.Equals, value: 2).IsOn(value));
+
+    [Theory]
+    [InlineData(1u, false)]
+    [InlineData(2u, true)]
+    [InlineData(3u, true)]
+    public void AtLeast_IncludesTheThreshold(uint value, bool expected) =>
+        Assert.Equal(expected, Binding(op: LedCondition.AtLeast, value: 2).IsOn(value));
+
+    [Theory]
+    [InlineData(1u, true)]
+    [InlineData(2u, true)]
+    [InlineData(3u, false)]
+    public void AtMost_IncludesTheThreshold(uint value, bool expected) =>
+        Assert.Equal(expected, Binding(op: LedCondition.AtMost, value: 2).IsOn(value));
+
+    // ── Sanitize ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Sanitize_KeepsAUsableBinding()
+    {
+        var file = new LedMappingFile { Bindings = { Binding() } };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Single(clean.Bindings);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Sanitize_DropsAnAircraftThisBuildDoesNotKnow()
+    {
+        var file = new LedMappingFile { Bindings = { Binding(aircraft: "Su-27") } };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Empty(clean.Bindings);
+        Assert.Contains(warnings, w => w.Contains("Su-27"));
+    }
+
+    [Fact]
+    public void Sanitize_DropsALedTheDeviceDoesNotHave()
+    {
+        // Ap1 is an FCU/EFIS LED; the PAP-3 has no such legend.
+        var file = new LedMappingFile { Bindings = { Binding(device: LedDeviceFamily.Pap3, led: "Ap1") } };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Empty(clean.Bindings);
+        Assert.Contains(warnings, w => w.Contains("Ap1"));
+    }
+
+    [Fact]
+    public void Sanitize_DropsABindingWithNoControl()
+    {
+        var file = new LedMappingFile { Bindings = { Binding(control: "   ") } };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Empty(clean.Bindings);
+        Assert.Single(warnings);
+    }
+
+    [Fact]
+    public void Sanitize_KeepsOneUnusableBindingFromCostingTheRest()
+    {
+        var file = new LedMappingFile
+        {
+            Bindings =
+            {
+                Binding(led: "Ap1", control: "MASTER_CAUTION"),
+                Binding(aircraft: "Su-27"),
+                Binding(led: "Ap2", control: "GUN_READY"),
+            },
+        };
+
+        var (clean, _) = file.Sanitize(KnownAircraft);
+
+        Assert.Equal(2, clean.Bindings.Count);
+    }
+
+    [Fact]
+    public void Sanitize_CollapsesDuplicateSlotsKeepingTheLast()
+    {
+        var file = new LedMappingFile
+        {
+            Bindings =
+            {
+                Binding(control: "FIRST"),
+                Binding(control: "SECOND"),
+            },
+        };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Equal("SECOND", Assert.Single(clean.Bindings).Control);
+        Assert.Contains(warnings, w => w.Contains("Duplicate"));
+    }
+
+    [Fact]
+    public void Sanitize_MatchesAircraftAndLedCaseInsensitively()
+    {
+        var file = new LedMappingFile { Bindings = { Binding(aircraft: "a-10c", led: "AP1") } };
+
+        var (clean, warnings) = file.Sanitize(KnownAircraft);
+
+        Assert.Single(clean.Bindings);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void ForAircraft_ReturnsOnlyThatAircraftsBindings()
+    {
+        var file = new LedMappingFile
+        {
+            Bindings = { Binding(aircraft: "A-10C"), Binding(aircraft: "F/A-18C", led: "Ap2") },
+        };
+
+        Assert.Equal("Ap2", Assert.Single(file.ForAircraft("F/A-18C")).Led);
+    }
+
+    // ── Storage ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MissingFile_LoadsAsAnEmptyMapping()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ledmappings-{Guid.NewGuid():N}.json");
+
+        var result = LedMappingStorage.TryLoad(path);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value!.Bindings);
+    }
+
+    [Fact]
+    public void SavedMapping_RoundTrips()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ledmappings-{Guid.NewGuid():N}.json");
+        var saved = new LedMappingFile
+        {
+            Bindings = { Binding(device: LedDeviceFamily.Pap3, led: "CmdA", op: LedCondition.Equals, value: 3) },
+        };
+
+        try
+        {
+            Assert.True(LedMappingStorage.TrySave(saved, path).IsSuccess);
+
+            // Enums are written as names so the file stays legible to whoever it is shared with.
+            Assert.Contains("\"Pap3\"", File.ReadAllText(path));
+
+            var loaded = LedMappingStorage.TryLoad(path).Value!;
+            var binding = Assert.Single(loaded.Bindings);
+
+            Assert.Equal(LedDeviceFamily.Pap3, binding.Device);
+            Assert.Equal("CmdA", binding.Led);
+            Assert.Equal(LedCondition.Equals, binding.Op);
+            Assert.Equal(3u, binding.Value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void UnreadableFile_FailsWithoutThrowing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ledmappings-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{ not json");
+
+        try
+        {
+            Assert.False(LedMappingStorage.TryLoad(path).IsSuccess);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // ── Catalog ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EveryFamilyHasLeds()
+    {
+        Assert.NotEmpty(LedCatalog.Families);
+        Assert.All(LedCatalog.Families, f => Assert.NotEmpty(LedCatalog.For(f)));
+    }
+
+    [Fact]
+    public void LedIdsAreUniqueWithinAFamily()
+    {
+        foreach (var family in LedCatalog.Families)
+        {
+            var ids = LedCatalog.For(family).Select(d => d.Id).ToList();
+            Assert.Equal(ids.Count, ids.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        }
+    }
+
+    [Fact]
+    public void FrontpanelLedsHaveASetter_AndMcduLedsDoNot()
+    {
+        foreach (var family in LedCatalog.Families.Where(f => f != LedDeviceFamily.Mcdu))
+            Assert.All(LedCatalog.For(family), d => Assert.NotNull(d.Set));
+
+        Assert.All(LedCatalog.For(LedDeviceFamily.Mcdu), d => Assert.Null(d.Set));
+    }
+
+    [Fact]
+    public void EveryMcduLedIdResolvesToAnAnnunciator()
+    {
+        Assert.All(LedCatalog.For(LedDeviceFamily.Mcdu), d => Assert.NotNull(LedCatalog.ParseMcduLed(d.Id)));
+    }
+
+    [Fact]
+    public void FcuEfisSettersEachReachTheirOwnLed() =>
+        AssertSettersAreDistinct(LedDeviceFamily.FcuEfis, () => new FcuEfisLeds(), LitBoolProperties);
+
+    [Fact]
+    public void Pap3SettersEachReachTheirOwnLed() =>
+        AssertSettersAreDistinct(LedDeviceFamily.Pap3, () => new Pap3Leds(), LitBoolProperties);
+
+    [Fact]
+    public void Agp32SettersEachReachTheirOwnLed() =>
+        AssertSettersAreDistinct(
+            LedDeviceFamily.Agp32,
+            () => new Agp32State.Agp32Leds(),
+            leds => ((Agp32State.Agp32Leds)leds).States.Where(s => s.Value).Select(s => s.Key.ToString()));
+
+    /// <summary>
+    /// A catalog entry is only useful if it lights exactly one LED, and a different one from
+    /// every other entry — a copy-paste slip in a table this long is otherwise invisible until
+    /// someone with the hardware notices two legends moving together.
+    /// </summary>
+    private static void AssertSettersAreDistinct(
+        LedDeviceFamily family,
+        Func<IFrontpanelLeds> create,
+        Func<IFrontpanelLeds, IEnumerable<string>> lit)
+    {
+        var reached = new Dictionary<string, string>();
+
+        foreach (var descriptor in LedCatalog.For(family))
+        {
+            var leds = create();
+            descriptor.Set!(leds, true);
+
+            var on = lit(leds).ToList();
+            var single = Assert.Single(on);
+
+            Assert.False(reached.ContainsKey(single),
+                $"{family}: {descriptor.Id} and {reached.GetValueOrDefault(single)} both drive {single}");
+            reached[single] = descriptor.Id;
+        }
+    }
+
+    private static IEnumerable<string> LitBoolProperties(IFrontpanelLeds leds) =>
+        leds.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(bool) && (bool)p.GetValue(leds)!)
+            .Select(p => p.Name);
+}

--- a/UI/DcsBiosControlCatalog.cs
+++ b/UI/DcsBiosControlCatalog.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DCS_BIOS.Json;
+using DCS_BIOS.Serialized;
+
+namespace WCtrlDcsBiosBridge.UI;
+
+/// <summary>
+/// One DCS-BIOS control the user can bind, as shown in the picker.
+/// </summary>
+public sealed record ControlChoice(string Identifier, string Description, string Category, int MaxValue, bool IsLamp)
+{
+    /// <summary>What the picker shows: the human description first, the identifier to confirm it.</summary>
+    public string Display => $"{Description} ({Identifier})";
+
+    /// <summary>
+    /// Whether a plain on/off test is not enough. A lamp is 0 or 1; a selector or a gauge
+    /// needs the user to say which position lights the LED.
+    /// </summary>
+    public bool NeedsCondition => MaxValue > 1;
+
+    public override string ToString() => Display;
+}
+
+/// <summary>
+/// Turns a module's DCS-BIOS controls into the list the LED editor offers. Separate from the
+/// panel so the rules can be tested without a window.
+/// </summary>
+public static class DcsBiosControlCatalog
+{
+    /// <summary>The DCS-BIOS control_type that marks an indicator lamp.</summary>
+    private const string LampControlType = "led";
+
+    /// <summary>
+    /// The controls a LED can follow: those with an integer output. String outputs (CDU
+    /// lines, counters) have no on/off reading, so they are left out entirely.
+    /// </summary>
+    public static IReadOnlyList<ControlChoice> Bindable(IEnumerable<DCSBIOSControl>? controls)
+    {
+        if (controls is null) return Array.Empty<ControlChoice>();
+
+        return controls
+            .Where(c => c?.Outputs != null && c.Outputs.Any(o => o.OutputDataType == DCSBiosOutputType.IntegerType))
+            .Select(c => new ControlChoice(
+                c.Identifier ?? string.Empty,
+                string.IsNullOrWhiteSpace(c.Description) ? c.Identifier ?? string.Empty : c.Description,
+                c.Category ?? string.Empty,
+                c.Outputs.First(o => o.OutputDataType == DCSBiosOutputType.IntegerType).MaxValue,
+                string.Equals(c.ControlType, LampControlType, StringComparison.OrdinalIgnoreCase)))
+            .Where(c => c.Identifier.Length > 0)
+            .OrderBy(c => c.Category, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.Description, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// What the picker shows: the module's indicator lamps, or every integer output when the
+    /// user asked for all of them — or when the module declares no lamp at all, since an
+    /// empty list would just look broken.
+    /// </summary>
+    public static IReadOnlyList<ControlChoice> Visible(IReadOnlyList<ControlChoice> all, bool showEverything)
+    {
+        if (showEverything) return all;
+
+        var lamps = all.Where(c => c.IsLamp).ToList();
+        return lamps.Count > 0 ? lamps : all;
+    }
+
+    /// <summary>Whether the lamp filter would hide nothing, because the module declares none.</summary>
+    public static bool HasLamps(IReadOnlyList<ControlChoice> all) => all.Any(c => c.IsLamp);
+}

--- a/UI/LedMappingPanel.xaml
+++ b/UI/LedMappingPanel.xaml
@@ -1,0 +1,131 @@
+<UserControl
+    x:Class="WCtrlDcsBiosBridge.UI.LedMappingPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid Margin="14,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
+            <TextBlock x:Name="LedMappingHeader" x:Uid="LedMappingHeader" Text="LED MAPPING"
+                       FontWeight="SemiBold" FontSize="11"
+                       Foreground="{StaticResource SubtleTextForeground}"
+                       VerticalAlignment="Center"/>
+            <Border x:Name="InUseBadge" Margin="8,0,0,0" CornerRadius="4" Padding="6,2"
+                    VerticalAlignment="Center" Visibility="Collapsed"
+                    Background="#1AE65100" BorderBrush="#E65100" BorderThickness="1">
+                <TextBlock x:Name="InUseBadgeText" x:Uid="LedMappingInUseBadge"
+                           Text="In use — stop the bridge to change it"
+                           FontSize="10" Foreground="#E65100"/>
+            </Border>
+        </StackPanel>
+
+        <TextBlock Grid.Row="1" x:Name="LedMappingIntro" x:Uid="LedMappingIntro"
+                   Text="Bind a DCS-BIOS indicator to any LED on your panels."
+                   TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+        <!-- Aircraft / panel selection -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock x:Name="AircraftLabel" x:Uid="LedMappingAircraftLabel" Text="Aircraft:"
+                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <ComboBox x:Name="AircraftCombo" MinWidth="140"
+                      SelectionChanged="Aircraft_Changed"/>
+
+            <TextBlock x:Name="DeviceLabel" x:Uid="LedMappingDeviceLabel" Text="Panel:"
+                       VerticalAlignment="Center" Margin="16,0,8,0"/>
+            <ComboBox x:Name="DeviceCombo" MinWidth="140"
+                      SelectionChanged="Device_Changed"/>
+
+            <CheckBox x:Name="AdvancedOption" x:Uid="LedMappingAdvancedOption"
+                      Content="Show all integer outputs"
+                      Margin="16,0,0,0" VerticalAlignment="Center"
+                      Checked="Advanced_Changed" Unchecked="Advanced_Changed"/>
+        </StackPanel>
+
+        <!-- Notice: no JSON path configured, or the module declares no lamp -->
+        <Border Grid.Row="3" x:Name="NoticeBorder" Visibility="Collapsed"
+                CornerRadius="4" Padding="10,7" Margin="0,0,0,10"
+                Background="#1AE65100" BorderBrush="#E65100" BorderThickness="1">
+            <TextBlock x:Name="NoticeText" TextWrapping="Wrap" FontSize="12" Foreground="#E65100"/>
+        </Border>
+
+        <!-- One row per LED of the selected panel -->
+        <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <Grid Margin="0,0,0,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="150"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" x:Name="LedColumnHeader" x:Uid="LedMappingLedHeader" Text="LED"
+                               FontWeight="SemiBold" FontSize="11"
+                               Foreground="{StaticResource SubtleTextForeground}"/>
+                    <TextBlock Grid.Column="1" x:Name="ControlColumnHeader" x:Uid="LedMappingControlHeader"
+                               Text="DCS-BIOS control" FontWeight="SemiBold" FontSize="11"
+                               Foreground="{StaticResource SubtleTextForeground}"/>
+                </Grid>
+
+                <ItemsControl x:Name="LedRows">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <!-- ContentControl, not the Grid: a Panel has no IsEnabled, and the
+                                 whole row goes read-only while the bridge runs this aircraft. -->
+                            <ContentControl IsEnabled="{Binding IsEnabled}" IsTabStop="False"
+                                            HorizontalContentAlignment="Stretch">
+                            <Grid Margin="0,3">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="150"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" Text="{Binding Label}"
+                                           VerticalAlignment="Center" Margin="0,0,8,0"
+                                           TextTrimming="CharacterEllipsis"/>
+
+                                <AutoSuggestBox Grid.Column="1" x:Name="ControlBox"
+                                                PlaceholderText="{Binding BuiltIn}"
+                                                TextMemberPath="Display"
+                                                DisplayMemberPath="Display"
+                                                Loaded="ControlBox_Loaded"
+                                                TextChanged="ControlBox_TextChanged"
+                                                SuggestionChosen="ControlBox_SuggestionChosen"
+                                                QuerySubmitted="ControlBox_QuerySubmitted"/>
+
+                                <ComboBox Grid.Column="2" MinWidth="96" Margin="8,0,0,0"
+                                          ItemsSource="{Binding ConditionNames}"
+                                          SelectedItem="{Binding ConditionName, Mode=TwoWay}"
+                                          Visibility="{Binding ConditionVisibility}"/>
+
+                                <NumberBox Grid.Column="3" MinWidth="86" Margin="8,0,0,0"
+                                           Minimum="0" SpinButtonPlacementMode="Compact"
+                                           Value="{Binding Value, Mode=TwoWay}"
+                                           Visibility="{Binding ConditionVisibility}"/>
+
+                                <Button Grid.Column="4" Content="✕" Margin="8,0,0,0"
+                                        Padding="8,4" Click="Clear_Click"/>
+                            </Grid>
+                            </ContentControl>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ScrollViewer>
+
+        <TextBlock Grid.Row="5" x:Name="RestartHint" x:Uid="LedMappingRestartHint"
+                   Text="Changes apply the next time the bridge starts."
+                   FontSize="11" Foreground="{StaticResource SubtleTextForeground}"
+                   TextWrapping="Wrap" Margin="0,10,0,0"/>
+    </Grid>
+</UserControl>

--- a/UI/LedMappingPanel.xaml.cs
+++ b/UI/LedMappingPanel.xaml.cs
@@ -1,0 +1,507 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using DCS_BIOS.ControlLocator;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WCtrlDcsBiosBridge.Aircrafts;
+using WCtrlDcsBiosBridge.Common;
+using WCtrlDcsBiosBridge.Config;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
+
+namespace WCtrlDcsBiosBridge.UI;
+
+/// <summary>
+/// One row of the editor: a LED of the selected panel, and the binding (if any) the user
+/// gave it for the selected aircraft.
+/// </summary>
+public sealed class LedRowViewModel : INotifyPropertyChanged
+{
+    private string _control = string.Empty;
+    private LedCondition _condition = LedCondition.NotZero;
+    private double _value;
+    private bool _needsCondition;
+    private bool _isEnabled = true;
+    private string _builtIn = "—";
+
+    public LedRowViewModel(LedDescriptor led)
+    {
+        LedId = led.Id;
+        Label = led.Label;
+    }
+
+    public string LedId { get; }
+    public string Label { get; }
+
+    /// <summary>The bound DCS-BIOS control identifier; empty when the LED is unbound.</summary>
+    public string Control
+    {
+        get => _control;
+        set => Set(ref _control, value ?? string.Empty);
+    }
+
+    public LedCondition Condition
+    {
+        get => _condition;
+        set
+        {
+            if (Set(ref _condition, value))
+                OnPropertyChanged(nameof(ConditionName));
+        }
+    }
+
+    /// <summary>The threshold, as a double because that is what NumberBox binds to.</summary>
+    public double Value
+    {
+        get => _value;
+        set => Set(ref _value, value);
+    }
+
+    /// <summary>Whether the operator and threshold controls are shown for this row.</summary>
+    public bool NeedsCondition
+    {
+        get => _needsCondition;
+        set
+        {
+            if (Set(ref _needsCondition, value))
+                OnPropertyChanged(nameof(ConditionVisibility));
+        }
+    }
+
+    public Visibility ConditionVisibility => NeedsCondition ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// What this LED does when the row is empty — the control the aircraft already drives it
+    /// from, or a note that the listener works it out. Shown as the box's placeholder, so
+    /// clearing a binding puts the built-in back in view as well as back in force.
+    /// </summary>
+    public string BuiltIn
+    {
+        get => _builtIn;
+        set => Set(ref _builtIn, value);
+    }
+
+    /// <summary>False while the bridge is running this aircraft, so the row cannot be edited.</summary>
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set => Set(ref _isEnabled, value);
+    }
+
+    public bool IsBound => !string.IsNullOrWhiteSpace(Control);
+
+    public IReadOnlyList<string> ConditionNames { get; } = LedMappingPanel.ConditionNames;
+
+    /// <summary>The operator as a string, for the ComboBox.</summary>
+    public string ConditionName
+    {
+        get => Condition.ToString();
+        set
+        {
+            if (System.Enum.TryParse<LedCondition>(value, out var parsed))
+                Condition = parsed;
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private bool Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(name);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+
+/// <summary>
+/// Lets the user bind any DCS-BIOS indicator of an aircraft to any LED of a panel, so the
+/// mapping is no longer whatever the code happens to hard-code. Writes ledmappings.json
+/// through <see cref="LedMappingStore"/>; the bindings are picked up the next time a
+/// listener starts, which is why the aircraft in use is read-only here.
+/// </summary>
+public sealed partial class LedMappingPanel : UserControl
+{
+    /// <summary>Raised when the user changed a binding and the file should be written.</summary>
+    public event System.EventHandler? MappingChanged;
+
+    internal static IReadOnlyList<string> ConditionNames { get; } =
+        System.Enum.GetNames<LedCondition>();
+
+    /// <summary>
+    /// The aircraft that can be configured: those DCS-BIOS actually exports controls for.
+    /// The C-130J and F-14B(U) borrow another module's id purely so the control locator has
+    /// something to load — binding their neighbour's controls would light nothing.
+    /// </summary>
+    private static IReadOnlyList<AircraftDescriptor> Configurable { get; } =
+        AircraftRegistry.All.Where(d => d.DcsBiosModuleId is null).ToList();
+
+    private readonly ObservableCollection<LedRowViewModel> _rows = new();
+
+    /// <summary>Every binding the user has, across aircraft and panels — the file in memory.</summary>
+    private List<LedBinding> _bindings = new();
+
+    /// <summary>The selected aircraft's bindable controls, or empty when they could not be read.</summary>
+    private IReadOnlyList<ControlChoice> _controls = System.Array.Empty<ControlChoice>();
+
+    private string? _jsonDirectory;
+    private string? _detectedAircraft;
+    private bool _isLoading;
+
+    public LedMappingPanel()
+    {
+        InitializeComponent();
+
+        LedRows.ItemsSource = _rows;
+        AircraftCombo.ItemsSource = Configurable.Select(d => d.DisplayName).ToList();
+        DeviceCombo.ItemsSource = LedCatalog.Families.Select(f => FamilyLabel(f)).ToList();
+
+        Reload();
+    }
+
+    /// <summary>
+    /// The DCS-BIOS JSON directory from config.json. The editor reads module JSON directly
+    /// rather than going through the aircraft the bridge has loaded, so it can be used while
+    /// the bridge runs another module.
+    /// </summary>
+    public string? JsonDirectory
+    {
+        get => _jsonDirectory;
+        set
+        {
+            _jsonDirectory = value;
+            LoadControlsForSelectedAircraft();
+        }
+    }
+
+    /// <summary>Rereads the mapping file into the editor.</summary>
+    public void Reload()
+    {
+        _bindings = LedMappingStore.Current.Bindings.Select(Clone).ToList();
+
+        if (AircraftCombo.SelectedIndex < 0 && Configurable.Count > 0) AircraftCombo.SelectedIndex = 0;
+        if (DeviceCombo.SelectedIndex < 0 && LedCatalog.Families.Count > 0) DeviceCombo.SelectedIndex = 0;
+
+        LoadControlsForSelectedAircraft();
+    }
+
+    /// <summary>The editor's current state as a mapping file, ready to save.</summary>
+    public LedMappingFile BuildMapping() => new() { Bindings = _bindings.Select(Clone).ToList() };
+
+    /// <summary>
+    /// Marks the aircraft the bridge is currently running. Its bindings are registered when
+    /// the listener starts, so editing them mid-flight would silently do nothing — the rows
+    /// are locked and a badge says why, the same convention the options panel uses.
+    /// </summary>
+    public void SetDetectedAircraft(string? detectedAircraftName)
+    {
+        _detectedAircraft = detectedAircraftName;
+        UpdateInUseState();
+    }
+
+    /// <summary>Re-applies every static string from Strings\&lt;lang&gt;\Resources.resw.</summary>
+    public void Retranslate()
+    {
+        LedMappingHeader.Text = Strings.Get("LedMappingHeader");
+        LedMappingIntro.Text = Strings.Get("LedMappingIntro");
+        AircraftLabel.Text = Strings.Get("LedMappingAircraftLabel");
+        DeviceLabel.Text = Strings.Get("LedMappingDeviceLabel");
+        AdvancedOption.Content = Strings.Get("LedMappingAdvancedOption");
+        LedColumnHeader.Text = Strings.Get("LedMappingLedHeader");
+        ControlColumnHeader.Text = Strings.Get("LedMappingControlHeader");
+        InUseBadgeText.Text = Strings.Get("LedMappingInUseBadge");
+        RestartHint.Text = Strings.Get("LedMappingRestartHint");
+
+        UpdateNotice();
+    }
+
+    // ── Selection ────────────────────────────────────────────────────────────
+
+    private AircraftDescriptor? SelectedAircraft =>
+        AircraftCombo.SelectedIndex >= 0 && AircraftCombo.SelectedIndex < Configurable.Count
+            ? Configurable[AircraftCombo.SelectedIndex]
+            : null;
+
+    private LedDeviceFamily SelectedFamily =>
+        DeviceCombo.SelectedIndex >= 0 && DeviceCombo.SelectedIndex < LedCatalog.Families.Count
+            ? LedCatalog.Families[DeviceCombo.SelectedIndex]
+            : LedDeviceFamily.FcuEfis;
+
+    private void Aircraft_Changed(object sender, SelectionChangedEventArgs e) => LoadControlsForSelectedAircraft();
+
+    private void Device_Changed(object sender, SelectionChangedEventArgs e) => RebuildRows();
+
+    private void Advanced_Changed(object sender, RoutedEventArgs e) => UpdateNotice();
+
+    // ── Control list ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the selected module's controls straight from its JSON. Uses
+    /// <c>onlyDirectResult</c> so the locator's shared control list — the one a running
+    /// listener resolves its own controls against — is left untouched.
+    /// </summary>
+    private void LoadControlsForSelectedAircraft()
+    {
+        _controls = System.Array.Empty<ControlChoice>();
+
+        var descriptor = SelectedAircraft;
+        if (descriptor != null && !string.IsNullOrWhiteSpace(_jsonDirectory))
+        {
+            try
+            {
+                DCSBIOSControlLocator.JSONDirectory = _jsonDirectory;
+
+                // onlyDirectResult: the locator's shared control list belongs to whatever
+                // module the bridge is running — reading another one must not disturb it.
+                _controls = DcsBiosControlCatalog.Bindable(
+                    DCSBIOSControlLocator.GetModuleControlsFromJson(descriptor.JsonFile, onlyDirectResult: true));
+            }
+            catch (System.Exception ex)
+            {
+                App.Logger.Warn(ex, $"Could not read DCS-BIOS controls for {descriptor.DisplayName}");
+            }
+        }
+
+        RebuildRows();
+        UpdateNotice();
+    }
+
+    /// <summary>
+    /// The controls offered in the picker: the module's indicator lamps, or every integer
+    /// output when the user asked for all of them — or when the module declares no lamp at
+    /// all, since an empty list would just look broken.
+    /// </summary>
+    private IReadOnlyList<ControlChoice> VisibleControls =>
+        DcsBiosControlCatalog.Visible(_controls, showEverything: AdvancedOption.IsChecked == true);
+
+    private void UpdateNotice()
+    {
+        var noJson = string.IsNullOrWhiteSpace(_jsonDirectory) || _controls.Count == 0;
+        NoticeText.Text = noJson
+            ? Strings.Get("LedMappingNoControls")
+            : (AdvancedOption.IsChecked != true && !DcsBiosControlCatalog.HasLamps(_controls)
+                ? Strings.Get("LedMappingNoLamps")
+                : string.Empty);
+        NoticeBorder.Visibility = string.IsNullOrEmpty(NoticeText.Text) ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    // ── Rows ─────────────────────────────────────────────────────────────────
+
+    private void RebuildRows()
+    {
+        _isLoading = true;
+        try
+        {
+            foreach (var row in _rows) row.PropertyChanged -= Row_PropertyChanged;
+            _rows.Clear();
+
+            var aircraft = SelectedAircraft?.DisplayName;
+            var family = SelectedFamily;
+            var defaults = aircraft is null
+                ? AircraftLedDefaults.None
+                : LedDefaults.ForDisplayName(aircraft);
+
+            foreach (var led in LedCatalog.For(family))
+            {
+                var row = new LedRowViewModel(led) { BuiltIn = DescribeBuiltIn(led, family, defaults) };
+                var existing = aircraft is null
+                    ? null
+                    : _bindings.FirstOrDefault(b =>
+                        string.Equals(b.Aircraft, aircraft, System.StringComparison.OrdinalIgnoreCase)
+                        && b.Device == family
+                        && string.Equals(b.Led, led.Id, System.StringComparison.OrdinalIgnoreCase));
+
+                if (existing != null)
+                {
+                    row.Control = existing.Control;
+                    row.Condition = existing.Op;
+                    row.Value = existing.Value;
+                }
+
+                row.NeedsCondition = FindControl(row.Control)?.NeedsCondition ?? (row.Condition != LedCondition.NotZero);
+                row.PropertyChanged += Row_PropertyChanged;
+                _rows.Add(row);
+            }
+
+            UpdateInUseState();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// What this aircraft already does with the LED, in the row's own words. The bare
+    /// identifier rather than the picker's fuller wording: a placeholder sits behind an empty
+    /// box and has to stay short, and the descriptions carry parentheses of their own.
+    /// </summary>
+    private string DescribeBuiltIn(LedDescriptor led, LedDeviceFamily family, AircraftLedDefaults defaults)
+    {
+        var info = family == LedDeviceFamily.Mcdu
+            ? (LedCatalog.ParseMcduLed(led.Id) is McduLed mcduLed ? defaults.For(mcduLed) : LedDefaultInfo.None)
+            : (led.Signal is FlightDeckSignal signal ? defaults.For(signal) : LedDefaultInfo.None);
+
+        if (info.Describe() is { } controls)
+            return Strings.Format("LedMappingBuiltInFormat", controls);
+
+        if (info.ComputedFrom != null)
+            return Strings.Format("LedMappingComputedFormat", info.ComputedFrom);
+
+        return "—";
+    }
+
+    private ControlChoice? FindControl(string identifier) =>
+        string.IsNullOrWhiteSpace(identifier)
+            ? null
+            : _controls.FirstOrDefault(c => string.Equals(c.Identifier, identifier, System.StringComparison.OrdinalIgnoreCase));
+
+    private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_isLoading || sender is not LedRowViewModel row) return;
+        if (e.PropertyName is nameof(LedRowViewModel.IsEnabled)
+            or nameof(LedRowViewModel.NeedsCondition)
+            or nameof(LedRowViewModel.ConditionName)
+            or nameof(LedRowViewModel.BuiltIn)) return;
+
+        CommitRow(row);
+    }
+
+    /// <summary>Writes one row back into the in-memory file and asks for a save.</summary>
+    private void CommitRow(LedRowViewModel row)
+    {
+        var aircraft = SelectedAircraft?.DisplayName;
+        if (aircraft is null) return;
+
+        var family = SelectedFamily;
+        _bindings.RemoveAll(b =>
+            string.Equals(b.Aircraft, aircraft, System.StringComparison.OrdinalIgnoreCase)
+            && b.Device == family
+            && string.Equals(b.Led, row.LedId, System.StringComparison.OrdinalIgnoreCase));
+
+        if (row.IsBound)
+        {
+            _bindings.Add(new LedBinding
+            {
+                Aircraft = aircraft,
+                Device = family,
+                Led = row.LedId,
+                Control = row.Control.Trim(),
+                Op = row.Condition,
+                Value = double.IsFinite(row.Value) && row.Value > 0 ? (uint)row.Value : 0,
+            });
+        }
+
+        MappingChanged?.Invoke(this, System.EventArgs.Empty);
+    }
+
+    private void UpdateInUseState()
+    {
+        var inUse = _detectedAircraft != null
+                    && string.Equals(SelectedAircraft?.DisplayName, _detectedAircraft, System.StringComparison.Ordinal);
+
+        foreach (var row in _rows) row.IsEnabled = !inUse;
+        InUseBadge.Visibility = inUse ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    // ── Row controls ─────────────────────────────────────────────────────────
+
+    private void ControlBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput) return;
+
+        var query = sender.Text?.Trim() ?? string.Empty;
+        var matches = VisibleControls
+            .Where(c => query.Length == 0
+                        || c.Identifier.Contains(query, System.StringComparison.OrdinalIgnoreCase)
+                        || c.Description.Contains(query, System.StringComparison.OrdinalIgnoreCase))
+            .Take(50)
+            .ToList();
+
+        sender.ItemsSource = matches;
+
+        // Typing something that matches no control unbinds the LED rather than silently
+        // keeping the old one: what the box shows is what the LED follows.
+        if (sender.DataContext is LedRowViewModel row && !matches.Any(m => m.Identifier == row.Control))
+            SetRowControl(row, FindByDisplay(query));
+    }
+
+    private void ControlBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (sender.DataContext is LedRowViewModel row && args.SelectedItem is ControlChoice choice)
+            SetRowControl(row, choice);
+    }
+
+    private void ControlBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        if (sender.DataContext is not LedRowViewModel row) return;
+
+        var choice = args.ChosenSuggestion as ControlChoice ?? FindByDisplay(sender.Text);
+        SetRowControl(row, choice);
+        sender.Text = choice?.Display ?? string.Empty;
+    }
+
+    private ControlChoice? FindByDisplay(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        return VisibleControls.FirstOrDefault(c =>
+                   string.Equals(c.Display, text, System.StringComparison.OrdinalIgnoreCase))
+               ?? VisibleControls.FirstOrDefault(c =>
+                   string.Equals(c.Identifier, text.Trim(), System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void SetRowControl(LedRowViewModel row, ControlChoice? choice)
+    {
+        row.NeedsCondition = choice?.NeedsCondition ?? false;
+        if (!row.NeedsCondition) row.Condition = LedCondition.NotZero;
+        row.Control = choice?.Identifier ?? string.Empty;
+    }
+
+    private void Clear_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement element || element.DataContext is not LedRowViewModel row) return;
+
+        SetRowControl(row, null);
+        row.Value = 0;
+
+        // The box is this button's sibling. Its x:Name lives in the template's own namescope,
+        // so looking it up from the item container would come back empty.
+        if (element.Parent is Panel panel)
+        {
+            foreach (var child in panel.Children)
+            {
+                if (child is AutoSuggestBox box) box.Text = string.Empty;
+            }
+        }
+    }
+
+    private void ControlBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is AutoSuggestBox box && box.DataContext is LedRowViewModel row)
+            box.Text = FindControl(row.Control)?.Display ?? row.Control;
+    }
+
+    private static LedBinding Clone(LedBinding binding) => new()
+    {
+        Aircraft = binding.Aircraft,
+        Device = binding.Device,
+        Led = binding.Led,
+        Control = binding.Control,
+        Op = binding.Op,
+        Value = binding.Value,
+    };
+
+    private static string FamilyLabel(LedDeviceFamily family) => family switch
+    {
+        LedDeviceFamily.FcuEfis => "FCU / EFIS",
+        LedDeviceFamily.Pap3 => "PAP-3",
+        LedDeviceFamily.Agp32 => "AGP-32",
+        LedDeviceFamily.Mcdu => "MCDU / PFP",
+        _ => family.ToString(),
+    };
+}

--- a/docs/LED-Mapping.md
+++ b/docs/LED-Mapping.md
@@ -1,0 +1,95 @@
+# LED mapping
+
+Every LED on a Winctrl front panel or CDU can follow any DCS-BIOS indicator of the aircraft
+you fly.
+
+Most aircraft already light some of them — the AGP32 gear lights, the CDU's master caution.
+Those are the **built-in** defaults, and you can see them: open the LEDs tab and each row
+shows the control it already follows, greyed out. Bind something of your own and it takes over
+that LED; clear the row and the built-in comes back. The FCU/EFIS and PAP3 legends start empty
+on every aircraft, because nothing in an A-10C means "AP1" — those light only once you say
+what they should follow.
+
+A built-in can watch more than one control: the F-14B's gear warning lights when any of three
+OFF lights does, and shows as *PLT_GEAR_L_OFF_L +2*. A few are worked out in code instead —
+the M-2000C reads its annunciators out of a lighting register, so there is no control to name
+and the row says *built-in, from PCN light register* instead. Either way you can bind over them.
+
+## Binding a LED
+
+1. Open the **LEDs** tab.
+2. Pick the **aircraft** and the **panel**.
+3. On the LED you want, start typing in the DCS-BIOS control box — by name (`MASTER_CAUTION`)
+   or by description ("master caution") — and pick from the list.
+4. Restart the bridge. Bindings are read when the aircraft's listener starts, so the aircraft
+   currently flying is read-only and shows an *in use* badge.
+
+The box lists the module's **indicator lamps** — that is 95 of the A-10C's controls, 130 of the
+F-16C's. Tick **Show all integer outputs** to reach everything else: switch positions, selectors,
+gauges. String outputs (CDU lines, counters) are never listed: there is no on/off to read from
+them.
+
+A lamp is simply on or off. When you bind something with more than two positions, an operator
+and a value appear next to it, so you can say *lit when the gear lever is at least 1*.
+
+## What wins
+
+A binding you make replaces the built-in behaviour of that LED, and only that LED. Bind the
+AGP32's `GEAR 1 DOWN` to something else and the other gear lights keep working as before.
+
+One built-in can drive several LEDs: a single gear-in-transit warning lights the AGP32's three
+red UNLK triangles and the lever's red arrow together, which is why those four rows all name
+the same control.
+
+Turning on **Disable Lighting Management** (for SimApp Pro users) switches off your own
+bindings, so nothing this app does fights the software that owns your panel lighting. The
+built-in defaults are unaffected by that setting, as they always have been.
+
+## Panels and their LEDs
+
+| Panel | LEDs |
+|---|---|
+| FCU / EFIS | LOC, AP1, AP2, A/THR, EXPED, APPR, and FD / LS / CSTR / WPT / VOR.D / NDB / ARPT on each side |
+| PAP-3 | N1, SPEED, VNAV, LVL CHG, HDG SEL, LNAV, VOR LOC, APP, ALT HOLD, V/S, CMD A, CWS A, CMD B, CWS B, A/T ARM, FD (L), FD (R) |
+| AGP-32 | the three gear DOWN and UNLK lights, GEAR DOWN (red), BRK FAN HOT / ON, the six AUTO BRK lights, TERR ON ND |
+| MCDU / PFP | FAIL, FM1, FM2, FM, IND, RDY |
+
+The PDC-3 has no LEDs of its own and is not listed.
+
+The C-130J and the F-14B(U) cannot be configured: DCS-BIOS carries no module for either, so
+there are no controls to bind. Everything those two show comes from the live data export.
+
+## The file
+
+Bindings live in `ledmappings.json`, next to the executable, apart from `useroptions.json` so
+that a mapping can be shared as it stands — post the file, drop it in, restart.
+
+```json
+{
+  "Version": 1,
+  "Bindings": [
+    {
+      "Aircraft": "A-10C",
+      "Device": "FcuEfis",
+      "Led": "Ap1",
+      "Control": "MASTER_CAUTION",
+      "Op": "NotZero",
+      "Value": 0
+    }
+  ]
+}
+```
+
+- `Aircraft` — the name as the app shows it (`A-10C`, `F/A-18C`, …).
+- `Device` — `FcuEfis`, `Pap3`, `Agp32` or `Mcdu`.
+- `Led` — the LED id, as the editor lists it.
+- `Op` — `NotZero` (the default), `Equals`, `AtLeast` or `AtMost`; `Value` is ignored by
+  `NotZero`.
+
+Only your own bindings are stored. The built-in defaults ship with the app, so an aircraft
+whose defaults are fixed or extended in a later release picks them up without you touching
+the file.
+
+A file written for an older release, or for a module DCS-BIOS has since changed, still loads:
+entries naming an aircraft, a LED or a control that no longer exists are skipped with a line in
+`log.txt`, and everything else is applied.


### PR DESCRIPTION
Now in the LED tab, you can 
- per Aircraft and per supported Device 
- choose which indicator ( the list is Limited to some DCSBIOS "light" indicators) 

<img width="1000" height="921" alt="image" src="https://github.com/user-attachments/assets/3333477e-4b64-4861-bb41-19b0e67f1f21" />
