### PR TITLE
Scope the Lua export script section in the release template

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -9,6 +9,10 @@
 
 ### Installing the Lua export script
 
+**Only needed for some aircraft.** Required for the **F-14B(U)** (CDNU) and the **C-130J**
+(CNI-MU), and optional for the **A-10C**, where it pre-fills wind and elevation on the
+performance pages. Every other aircraft works without it — skip this section.
+
 Follow **[docs/Export-Script-Setup.md](https://github.com/landre-cerp/WCtrlDcsBiosBridge/blob/{{TAG}}/docs/Export-Script-Setup.md)**.
 
 In short: extract `wctrl-export-scripts-{{TAG}}.zip` into `%USERPROFILE%\Saved Games\DCS\`,


### PR DESCRIPTION
The **Installing the Lua export script** section of the release template read as if every user had to install the Lua script before running the app.

It is only required for the **F-14B(U)** (CDNU) and the **C-130J** (CNI-MU), and optional for the **A-10C**, where it pre-fills wind and elevation on the performance pages. Every other aircraft works without it.

The Downloads table already carried this nuance, but the section header did not — so the qualification now appears before the reader starts following the instructions.

Template text only, no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
