### PR TITLE
C-130J: take the real DCS-BIOS module

### DIFF
--- a/Aircrafts/AircraftRegistry.cs
+++ b/Aircrafts/AircraftRegistry.cs
@@ -105,20 +105,21 @@ internal static class AircraftRegistry
         c => new F14BU_Listener(c.Options),
         DcsBiosModuleId: 16);
 
-    // Same situation as the F-14B(U): DCS-BIOS has no C-130J module, so MetadataStart reports
-    // the name and nothing else follows. Everything shown comes from wctrl-export.lua, laid
-    // out against Resources/c130j-cni-pages.json. It borrows the A-10C DCS-BIOS id and json
-    // purely so the control locator has a real module to load; neither is read.
+    // DCS-BIOS carries this aircraft, but not its CNI-MU: the module declares every switch and
+    // lamp and not one line of the display. So the panel's LEDs come off DCS-BIOS like any
+    // other aircraft's, while the screen still comes from wctrl-export.lua, laid out against
+    // Resources/c130j-cni-pages.json.
+    //
+    // Id 51 is ours rather than DCSFlightpanels' — see the note in dcs-bios_modules.txt.
     //
     // The font is the A-10C's with one glyph redrawn. A CDU font's bitmaps need not look like
     // the characters they are filed under — the A-10C's U+2610 is an open-ended bracket pair,
     // which is what that aircraft wants there. The CNI uses the slot for an empty entry field
     // and wants a closed box, in both sizes.
     public static readonly AircraftDescriptor C130J = new(
-        1030, "C-130J", "A-10C.json", "Resources/c130j-font-21x31.json", true,
+        51, "C-130J", "C-130J.json", "Resources/c130j-font-21x31.json", true,
         new[] { "C-130J" },
-        c => new C130J_Listener(c.Options, c.IsPilot),
-        DcsBiosModuleId: 5);
+        c => new C130J_Listener(c.Options, c.IsPilot));
 
     /// <summary>
     /// Registry order is menu order. It is also match order for

--- a/Aircrafts/C130J/C130J_Listener.cs
+++ b/Aircrafts/C130J/C130J_Listener.cs
@@ -5,10 +5,10 @@ namespace WCtrlDcsBiosBridge.Aircrafts.C130J;
 /// <summary>
 /// C-130J CNI-MU repeater.
 ///
-/// DCS-BIOS has no module for this aircraft, so nothing arrives on the DCS-BIOS stream while
-/// it is loaded. Everything shown here comes from the wctrl-export.lua UDP feed, which scrapes
-/// the pilot's and the copilot's CNI, and the CNI is therefore the only page this listener
-/// offers.
+/// DCS-BIOS carries the aircraft but not its CNI-MU — the module declares every switch and
+/// lamp and not one line of the display. What is shown here therefore comes from the
+/// wctrl-export.lua UDP feed, which scrapes the pilot's and the copilot's CNI, and the CNI is
+/// the only page this listener offers.
 ///
 /// One listener drives one CDU and answers to one seat, named at construction and fixed for the
 /// life of the listener: the copilot's CNI reaches a panel only when a second CDU has been given
@@ -20,10 +20,12 @@ namespace WCtrlDcsBiosBridge.Aircrafts.C130J;
 /// size, no highlight. The layout comes from <c>Resources/c130j-cni-pages.json</c>, extracted
 /// offline from the module's own page scripts by <c>tools/cni-schema</c>.
 ///
-/// One lamp comes off the same feed: the CNI-MU's EXEC annunciator, which no argument and no
-/// cockpit parameter reports. <see cref="CniExecLamp"/> works it out from the page title and
-/// the EXEC keypresses, and holds it — the marker is only on the modified page, so a lamp
-/// recomputed from whatever page is on screen would go out the moment the crew turned away.
+/// One lamp comes off the same feed: the CNI-MU's EXEC annunciator, which nothing readable
+/// reports. DCS-BIOS declares it as PLT_CNI_EXEC_LED on cockpit argument 3390, but that
+/// argument never leaves zero — tried, and the lamp stayed dark. <see cref="CniExecLamp"/>
+/// works it out from the page title and the EXEC keypresses instead, and holds it — the marker
+/// is only on the modified page, so a lamp recomputed from whatever page is on screen would go
+/// out the moment the crew turned away.
 /// That lamp is the aircraft's rather than the seat's, so it is fed both seats' packets while
 /// the screen is fed only this one's.
 /// </summary>
@@ -109,7 +111,7 @@ internal sealed class C130J_Listener : AircraftListener
 
     protected override void RegisterCduControls() => RenderPlaceholder();
 
-    // Nothing to register: DCS-BIOS exports no controls for the C-130J.
+    // The gear lights and the master caution are declared in LedDefaults, which registers them.
     protected override void RegisterFrontpanelControls() { }
 
     // Runs on the UDP receiver thread, like the F-14B(U) and A-10C live export paths.

--- a/Aircrafts/LedDefaults.cs
+++ b/Aircrafts/LedDefaults.cs
@@ -226,12 +226,24 @@ public static class LedDefaults
             },
         },
 
-        // C-130J — DCS-BIOS has no module for this aircraft, so nothing here can name a control.
-        // The CNI-MU's EXEC annunciator is read off the page title instead (see CniExecLamp),
-        // and it is declared on both lamps because the panels disagree on which one exists:
-        // EXEC on the PFPs, RDY on the MCDU.
-        [1030] = new AircraftLedDefaults
+        // C-130J — the gear and the master caution are the module's own controls. The CNI-MU's
+        // EXEC annunciator is not: DCS-BIOS declares PLT_CNI_EXEC_LED on cockpit argument 3390
+        // and that argument never leaves zero, so the lamp is read off the CNI page title
+        // instead (see CniExecLamp). It is declared on both annunciators because the panels
+        // disagree on which one exists: EXEC on the PFPs, RDY on the MCDU.
+        [51] = new AircraftLedDefaults
         {
+            Signals = new[]
+            {
+                new SignalDefault(FlightDeckSignal.GearLeftDown, "LANDING_GEAR_LOCKED_L"),
+                new SignalDefault(FlightDeckSignal.GearNoseDown, "LANDING_GEAR_LOCKED_C"),
+                new SignalDefault(FlightDeckSignal.GearRightDown, "LANDING_GEAR_LOCKED_R"),
+                new SignalDefault(FlightDeckSignal.GearWarning, "LANDING_GEAR_LEVER_LIGHT"),
+            },
+            McduLeds = new[]
+            {
+                new McduLedDefault(McduLed.Fail, "PLT_REF_MODE_MASTER_CAUTION_L"),
+            },
             ComputedMcduLeds = new Dictionary<McduLed, string>
             {
                 [McduLed.Exec] = "CNI page title (MOD prefix)",

--- a/DcsBios/dcs-bios_modules.txt
+++ b/DcsBios/dcs-bios_modules.txt
@@ -51,7 +51,7 @@ MH-60R|47|MH-60R SeaHawk
 F-4E|48|F-4E Phantom II
 OH-58D|49|OH-58D Kiowa Warrior
 CH-47F|50|CH-47 Chinook
-
+C-130J|51|C-130J Hercules
 MetadataEnd|500|MetadataEnd|CommonModules
 MetadataStart|501|MetadataStart|CommonModules
 CommonData|502|CommonData|CommonModules

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ this way. See [LED mapping](docs/LED-Mapping.md).
 ### DCS export script (optional)
 
 An extra Lua script, shipped as the `wctrl-export-scripts-<version>.zip` asset of each
-release. It is **required** for the F-14B(U) CDNU and the C-130J CNI-MU, neither of which
-DCS-BIOS exports, and **optional** for the A-10C, where it pre-fills live wind and field
+release. It is **required** for the F-14B(U) CDNU and the C-130J CNI-MU because DCS-BIOS
+exports the base C-130J module but not its CNI-MU display, and it exports neither the
+F-14B(U) CDNU data. It is **optional** for the A-10C, where it pre-fills live wind and field
 elevation on the takeoff performance page. See
 [Lua export script setup](docs/Export-Script-Setup.md).
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ brightness, and any front-panel output. Click an aircraft for details.
 
 [A-10C](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/A-10C) | [AH-64D](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/AH-64D) | [F/A-18C](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/FA-18C) | [CH-47F](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/CH-47F) | [OH-58D](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/OH-58D) | [F-14B](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/F-14B) | [F-15E](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/F-15E) | [F-16C](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/F-16C) | [M-2000C](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/M-2000C) | [UH-1H](https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/UH-1H)
 
-Two more are driven by the live data export rather than DCS-BIOS, which carries no module for
-them, and so show one display each: the **F-14B(U)** CDNU ([setup](docs/F-14BU-Setup.md)) and
-the **C-130J** CNI-MU ([setup](docs/C-130J-Setup.md)).
+Two more take their display from the live data export and show one page each: the
+**F-14B(U)** CDNU ([setup](docs/F-14BU-Setup.md)), which DCS-BIOS carries no module for at
+all, and the **C-130J** CNI-MU ([setup](docs/C-130J-Setup.md)), whose module is carried but
+whose display is not.
 
 Contributions: Smreki F15E , Mustang038 M200C, F16C Poussedebamboo, F18 Iefi pages Martin Javorek
 
@@ -81,8 +82,8 @@ this way. See [LED mapping](docs/LED-Mapping.md).
 ### DCS export script (optional)
 
 An extra Lua script, shipped as the `wctrl-export-scripts-<version>.zip` asset of each
-release. It is **required** for the F-14B(U) CDNU and the C-130J CNI-MU, which DCS-BIOS does
-not carry at all, and **optional** for the A-10C, where it pre-fills live wind and field
+release. It is **required** for the F-14B(U) CDNU and the C-130J CNI-MU, neither of which
+DCS-BIOS exports, and **optional** for the A-10C, where it pre-fills live wind and field
 elevation on the takeoff performance page. See
 [Lua export script setup](docs/Export-Script-Setup.md).
 

--- a/Tests/C130JRegistryTests.cs
+++ b/Tests/C130JRegistryTests.cs
@@ -1,4 +1,5 @@
 using WCtrlDcsBiosBridge.Aircrafts;
+using WCtrlDcsBiosBridge.Devices.Frontpanels;
 using Xunit;
 
 namespace WCtrlDcsBiosBridge.Tests;
@@ -20,18 +21,34 @@ public class C130JRegistryTests
     }
 
     /// <summary>
-    /// The id is synthetic because DCS-BIOS has no C-130J. It still has to borrow a real
-    /// module's id and json, or the control locator has nothing to load and the listener
-    /// throws on construction.
+    /// DCS-BIOS carries the aircraft now, so the descriptor names its own module rather than
+    /// borrowing the A-10C's. It borrowed one for as long as there was nothing else for the
+    /// control locator to load, at the cost of resolving another module's controls.
     /// </summary>
     [Fact]
-    public void BorrowsARealDcsBiosModule()
+    public void NamesItsOwnDcsBiosModule()
     {
-        Assert.NotEqual(AircraftRegistry.C130J.ModuleId,
-                        AircraftRegistry.C130J.EffectiveDcsBiosModuleId);
-        Assert.Equal(AircraftRegistry.A10C.ModuleId,
+        Assert.Null(AircraftRegistry.C130J.DcsBiosModuleId);
+        Assert.Equal(AircraftRegistry.C130J.ModuleId,
                      AircraftRegistry.C130J.EffectiveDcsBiosModuleId);
+        Assert.Equal("C-130J.json", AircraftRegistry.C130J.JsonFile);
         Assert.Contains(AircraftRegistry.C130J.JsonFile, AircraftRegistry.ExpectedJsonFiles);
+    }
+
+    /// <summary>
+    /// The gear and the master caution are named controls now that DCS-BIOS carries the module.
+    /// The EXEC annunciator is not, and cannot be: PLT_CNI_EXEC_LED sits on an argument that
+    /// never moves, so it stays something the listener works out.
+    /// </summary>
+    [Fact]
+    public void LightsWhatItCanFromNamedControls()
+    {
+        var defaults = LedDefaults.For(AircraftRegistry.C130J);
+
+        Assert.NotEmpty(defaults.Signals);
+        Assert.Contains(defaults.McduLeds, l => l.Led == McduLed.Fail);
+        Assert.DoesNotContain(defaults.McduLeds, l => l.Led == McduLed.Exec);
+        Assert.Contains(McduLed.Exec, defaults.ComputedMcduLeds.Keys);
     }
 
     /// <summary>

--- a/UI/LedMappingPanel.xaml.cs
+++ b/UI/LedMappingPanel.xaml.cs
@@ -162,8 +162,8 @@ public sealed partial class LedMappingPanel : UserControl
 
     /// <summary>
     /// The aircraft that can be configured: those DCS-BIOS actually exports controls for.
-    /// The C-130J and F-14B(U) borrow another module's id purely so the control locator has
-    /// something to load — binding their neighbour's controls would light nothing.
+    /// The F-14B(U) borrows another module's id purely so the control locator has something
+    /// to load — binding its neighbour's controls would light nothing.
     /// </summary>
     private static IReadOnlyList<AircraftDescriptor> Configurable { get; } =
         AircraftRegistry.All.Where(d => d.DcsBiosModuleId is null).ToList();

--- a/docs/Aircraft.md
+++ b/docs/Aircraft.md
@@ -5,7 +5,7 @@ Per-aircraft documentation has moved to the [project wiki](https://github.com/la
 | Aircraft | Wiki page |
 |----------|-----------|
 | A-10C | https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/A-10C |
-| C-130J | [C-130J-Setup.md](C-130J-Setup.md) — CNI-MU only, via the live export |
+| C-130J | [C-130J-Setup.md](C-130J-Setup.md) — CNI-MU via the live export, lamps via DCS-BIOS |
 | AH-64D | https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/AH-64D |
 | CH-47F | https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/CH-47F |
 | F-14B | https://github.com/landre-cerp/WCtrlDcsBiosBridge/wiki/F-14B |

--- a/docs/C-130J-Setup.md
+++ b/docs/C-130J-Setup.md
@@ -1,9 +1,14 @@
 # C-130J CNI-MU — in a hurry
 
-The C-130J is not carried by DCS-BIOS, so its CNI-MU pages come from the same export script
-the F-14B(U) uses, reading the display straight from the cockpit and sending it over UDP.
-Three steps, and if you already set up the F-14B(U) the first two are done.
+DCS-BIOS carries the C-130J, but not its CNI-MU: the module declares every switch and lamp
+and not one line of the display. So the panel's lamps come off DCS-BIOS like any other
+aircraft's, while the CNI-MU pages come from the same export script the F-14B(U) uses, reading
+the display straight from the cockpit and sending it over UDP. Three steps, and if you already
+set up the F-14B(U) the first two are done.
 
+> **A DCS-BIOS with the C-130J module is required.** Update it if the app reports
+> `C-130J.json` missing at start-up.
+>
 > The script and the app talk a versioned protocol. Take both from the **same release** —
 > a mismatched script is ignored and the page stays empty.
 
@@ -37,23 +42,27 @@ Load the C-130J in DCS and the CNI-MU appears on the CDU.
 
 ## What the C-130J shows
 
-**The CNI-MU, and nothing else.** DCS-BIOS has no module for this aircraft, so while it is
-loaded no C-130J data reaches the bridge: no gear, no clock, no switches. The augmented crew's
-display is not carried either.
+**The display is the CNI-MU, and nothing else.** DCS-BIOS does not export the CNI's screen, so
+the export script draws it; the augmented crew's display is not carried at all.
 
 Pages are recognised by the title they draw, so the CDU follows whatever the CNI is showing. A
 page the app does not recognise leaves the screen as it was rather than drawing it against the
 wrong layout.
+
+The **lamps** now come from DCS-BIOS: the gear lights and the master caution on the front
+panels. Every lamp the module declares — MSG, FAIL, DSPY and OFSET on each CNI, the mode
+annunciators, and the rest of the 126 — is offered in **LED mapping**, to bind to whichever
+LED you like. The EXEC annunciator is the exception, and has its own section below.
 
 ## The EXEC lamp
 
 The CDU's **EXEC** annunciator follows the CNI-MU's EXEC light. On an MCDU, which has no EXEC
 lamp, **RDY** shows it instead: the bridge drives both, and each panel lights the one it has.
 
-Nothing in the sim reports that lamp. It is not a cockpit animation argument — a sweep of every
-argument across a full EXEC cycle shows the key's own press pulse and nothing that stays lit —
-and it is not in `list_cockpit_params` either. So it is put together from two things that *are*
-readable, and then held.
+Nothing in the sim reports that lamp. DCS-BIOS appears to — it declares `PLT_CNI_EXEC_LED` on
+cockpit argument 3390 — but that argument never leaves zero: bound to the annunciator, the lamp
+stayed dark through a full EXEC cycle. It is not in `list_cockpit_params` either. So it is put
+together from two things that *are* readable, and then held.
 
 The first is the page title. The module builds the titles of its nineteen modifiable pages from
 a format with a leading marker, and the sim fills that in with `MOD ` while a change is waiting
@@ -168,6 +177,10 @@ been restarted since.
 
 `CNI SCHEMA MISSING` means `Resources\c130j-cni-pages.json` did not ship alongside the exe —
 reinstall rather than copying files around.
+
+A start-up warning naming `C-130J.json` means your DCS-BIOS predates the C-130J module. The
+CNI-MU itself still draws — it comes from the export script — but every lamp stays dark, and
+the log names each control it could not find. Update DCS-BIOS.
 
 `Scripts\wctrl-export\test_client.py` prints the raw feed on UDP 31090, which tells you
 whether DCS is sending before you start suspecting the bridge. The app's log reports a


### PR DESCRIPTION
DCS-BIOS ships a C-130J module now (1068 controls), so the aircraft stops borrowing the A-10C's
id and json.

## What changes

- **Its own module.** Registry id 51 with `C-130J.json`, no more `DcsBiosModuleId: 5`. The
  borrow existed only to give the control locator something to load; it also kept the C-130J out
  of the LED mapping editor, which lists the aircraft that name their own module. It is in the
  list now, with the module's 126 lamps.
- **`dcs-bios_modules.txt` gains `C-130J|51|C-130J Hercules`.** Id 51 is a local choice —
  DCSFlightpanels has not assigned one — so this file now diverges from the vendored DCSFPCommon
  copy it was a verbatim duplicate of. Worth knowing at the next submodule sync.
- **Gear and master caution are named controls** in `LedDefaults`, replacing an entry that could
  name none.
- A DCS-BIOS carrying the module is now **required**: `C-130J.json` joins `ExpectedJsonFiles` and
  its absence is reported at start-up like any other module's.

## What does not change

The **CNI-MU screen** still comes from `wctrl-export.lua`. The module declares every switch and
lamp and not one line of the display, so nothing about the rendering chain moves.

The **EXEC annunciator** still comes from `CniExecLamp`, after an attempt that failed. DCS-BIOS
declares `PLT_CNI_EXEC_LED` on cockpit argument 3390, which looked like it would replace the
whole heuristic — but that argument never leaves zero. The control resolves and DCS-BIOS streams
it (no `Built-in LED default ignored` in the log); the value simply never moves, and the lamp
stayed dark through a full EXEC cycle. The page title's `MOD `/`ACT ` marker and the EXEC
keypress count stay, and the docs now record why.

## Verified in the cockpit

- Three green gear lights on the front panel
- Master caution flashing FAIL
- CNI-MU pages and the EXEC/RDY annunciator unchanged

Untested: `GearWarning` going out on `LANDING_GEAR_LEVER_LIGHT` once the gear is locked.

387/387 tests pass; both Lua scripts parse under `luae`.

## Two DCS-BIOS bugs worth reporting upstream

1. `PLT_CNI_EXEC_LED` / `CPLT_CNI_EXEC_LED` / `AUG_CNI_EXEC_LED` sit on arguments 3390/3392/3394,
   which do not move.
2. `CPLT_CNI_EXEC` and `CPLT_CNI_DIR_INTC` have their arguments crossed — the module's
   `clickabledata.lua` gives 1187 for EXEC and 1192 for DIR INTC, DCS-BIOS declares the reverse.
   The commands are right, only the state readback is wrong. Blocking for any future key
   forwarding to the CNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
